### PR TITLE
fix: Fix tomap call for terraform 0.15

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "aws_cloudwatch_event_rule" "this" {
 resource "aws_cloudwatch_event_target" "this" {
   for_each = var.create && var.create_targets ? {
     for target in local.eventbridge_targets : target.name => target
-  } : tomap({})
+  } : {}
 
   event_bus_name = var.create_bus ? aws_cloudwatch_event_bus.this[0].name : "default"
 


### PR DESCRIPTION
## Description
The tomap call on empty map is not working on 0.15, which breakes the module.
The fix is just removing the call - and thats it.

Error message on 0.15.4:
```
╷
│ Error: Inconsistent conditional result types
│ 
│   on .terraform/modules/eventbridge/main.tf line 49, in resource "aws_cloudwatch_event_target" "this":
│   49:   for_each = var.create && var.create_targets ? {
│   50:     for target in local.eventbridge_targets : target.name => target
│   51:   } : tomap({})
│     ├────────────────
│     │ local.eventbridge_targets is tuple with 3 elements
│ 
│ The true result value has the wrong type: element types must all match for conversion to map.
╵
```

## Motivation and Context
Module does not run on 0.15.x

## Breaking Changes
none

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects 
