### PR TITLE
fix: remove create_bus as a blocker for role_arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ module "eventbridge" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.46.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.40 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ module "eventbridge" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.40 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.46.0 |
 
 ## Modules
 
@@ -320,7 +320,7 @@ No modules.
 | <a name="input_create_archives"></a> [create\_archives](#input\_create\_archives) | Controls whether EventBridge Archive resources should be created | `bool` | `false` | no |
 | <a name="input_create_bus"></a> [create\_bus](#input\_create\_bus) | Controls whether EventBridge Bus resource should be created | `bool` | `true` | no |
 | <a name="input_create_permissions"></a> [create\_permissions](#input\_create\_permissions) | Controls whether EventBridge Permission resources should be created | `bool` | `true` | no |
-| <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Controls whether IAM role for Lambda Function should be created | `bool` | `true` | no |
+| <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Controls whether IAM roles should be created | `bool` | `true` | no |
 | <a name="input_create_rules"></a> [create\_rules](#input\_create\_rules) | Controls whether EventBridge Rule resources should be created | `bool` | `true` | no |
 | <a name="input_create_targets"></a> [create\_targets](#input\_create\_targets) | Controls whether EventBridge Target resources should be created | `bool` | `true` | no |
 | <a name="input_ecs_target_arns"></a> [ecs\_target\_arns](#input\_ecs\_target\_arns) | The Amazon Resource Name (ARN) of the AWS ECS Tasks you want to use as EventBridge targets | `list(string)` | `[]` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 locals {
-  create_role = var.create && var.create_bus && var.create_role
+  create_role = var.create && var.create_role
 
   # Defaulting to "*" (an invalid character for an IAM Role name) will cause an error when
   # attempting to plan if the role_name and bus_name are not set. This is a workaround

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "create" {
 }
 
 variable "create_role" {
-  description = "Controls whether IAM role for Lambda Function should be created"
+  description = "Controls whether IAM roles should be created"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
## Description

Attempt to fix #12 

## Motivation and Context

If you're using the default eventbridge bus (required for scheduling), a role isn't attached. This is fine except for the ecs_target, which requires role_arn.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->