### PR TITLE
fix: `create_rules = false` causes error

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -24,16 +24,12 @@ output "eventbridge_permission_ids" {
 # EventBridge Rule
 output "eventbridge_rule_ids" {
   description = "The EventBridge Rule IDs created"
-  value = {
-    for p in sort(keys(var.rules)) : p => aws_cloudwatch_event_rule.this[p].id
-  }
+  value = var.create_rules ? { for p in sort(keys(var.rules)) : p => aws_cloudwatch_event_rule.this[p].id } : {}
 }
 
 output "eventbridge_rule_arns" {
   description = "The EventBridge Rule ARNs created"
-  value = {
-    for p in sort(keys(var.rules)) : p => aws_cloudwatch_event_rule.this[p].arn
-  }
+  value = var.create_rules ? { for p in sort(keys(var.rules)) : p => aws_cloudwatch_event_rule.this[p].arn } : {}
 }
 
 # IAM Role

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,12 +24,12 @@ output "eventbridge_permission_ids" {
 # EventBridge Rule
 output "eventbridge_rule_ids" {
   description = "The EventBridge Rule IDs created"
-  value = var.create_rules ? { for p in sort(keys(var.rules)) : p => aws_cloudwatch_event_rule.this[p].id } : {}
+  value       = var.create_rules ? { for p in sort(keys(var.rules)) : p => aws_cloudwatch_event_rule.this[p].id } : {}
 }
 
 output "eventbridge_rule_arns" {
   description = "The EventBridge Rule ARNs created"
-  value = var.create_rules ? { for p in sort(keys(var.rules)) : p => aws_cloudwatch_event_rule.this[p].arn } : {}
+  value       = var.create_rules ? { for p in sort(keys(var.rules)) : p => aws_cloudwatch_event_rule.this[p].arn } : {}
 }
 
 # IAM Role


### PR DESCRIPTION
## Description
`eventbridge_rule_ids` and `eventbridge_rule_arns` now return empty result when `create_rules` is set to `false`.

## Motivation and Context
`create_rules = false` causes errors if any rules are defined.

See issue #18 

## Breaking Changes
None.

## How Has This Been Tested?
I tested the change with the `default_bus` example as well as the production code that revealed the bug in the first place.
