### PR TITLE
feat: Support for existing event buses

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_event_rule" "this" {
   name        = each.value.Name
   name_prefix = lookup(each.value, "name_prefix", null)
 
-  event_bus_name = var.create_bus ? aws_cloudwatch_event_bus.this[0].name : "default"
+  event_bus_name = var.create_bus ? aws_cloudwatch_event_bus.this[0].name : var.bus_name
 
   description         = lookup(each.value, "description", null)
   is_enabled          = lookup(each.value, "enabled", true)
@@ -50,7 +50,7 @@ resource "aws_cloudwatch_event_target" "this" {
     for target in local.eventbridge_targets : target.name => target
   } : {}
 
-  event_bus_name = var.create_bus ? aws_cloudwatch_event_bus.this[0].name : "default"
+  event_bus_name = var.create_bus ? aws_cloudwatch_event_bus.this[0].name : var.bus_name
 
   rule = each.value.Name
   arn  = each.value.arn
@@ -185,5 +185,5 @@ resource "aws_cloudwatch_event_permission" "this" {
   statement_id = compact(split(" ", each.key))[1]
 
   action         = lookup(each.value, "action", null)
-  event_bus_name = try(each.value["event_bus_name"], aws_cloudwatch_event_bus.this[0].name, null)
+  event_bus_name = try(each.value["event_bus_name"], aws_cloudwatch_event_bus.this[0].name, var.bus_name, null)
 }


### PR DESCRIPTION
## Description
This PR adds support for using existing buses.  Instead of using the string `"default"` when `create_bus` is `false` the variable `bus_name` is used instead.  This variable defaults to the value `default` which should preserve its behavior.

## Motivation and Context
I needed to be able to write rules against an existing bus and setting `create_bus` to `false` forced the use of the event bus named `default`.

## Breaking Changes
I don't believe this introduces any breaking changes.

## How Has This Been Tested?
I deployed this against my own environment.  I was able to set `create_bus` to `false` and use the provided `bus_name` to target an existing event bus.