### PR TITLE
Update main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "aws_cloudwatch_event_rule" "this" {
 resource "aws_cloudwatch_event_target" "this" {
   for_each = var.create && var.create_targets ? {
     for target in local.eventbridge_targets : target.name => target
-  } : {}
+  } : to_map({})
 
   event_bus_name = var.create_bus ? aws_cloudwatch_event_bus.this[0].name : var.bus_name
 


### PR DESCRIPTION
For resource aws_cloudwatch_event_target, add explicit conversion using to_map for the empty object in ternary operator, to avoid the error "Error: Inconsistent conditional result types""

## Description
In file main.tf, for resource aws_cloudwatch_event_target, the for_each command has a ternary operator with default value for not-match as empty object : {}

In some cases, terraform is throwing error `Inconsistent conditional result types ...... The true and false result expressions must have consistent types. The given expressions are object and object, respectively.`

By explicitly type converting empty object to map, the error is resolved.

```
% terraform plan
╷
│ Error: Inconsistent conditional result types
│
│   on ../../main.tf line 49, in resource "aws_cloudwatch_event_target" "this":
│   49:   for_each = var.create && var.create_targets ? {
│   50:     for target in local.eventbridge_targets : target.name => target
│   51:   } : {}
│     ├────────────────
│     │ local.eventbridge_targets is tuple with 8 elements
│     │ var.create is true
│     │ var.create_targets is true
│
│ The true and false result expressions must have consistent types. The given expressions are object and object, respectively.

```

## Motivation and Context
Fix for Issue #23 

## Breaking Changes
Does this break backwards compatibility with the current major version? No

## How Has This Been Tested?
- [x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
For all the examples , ran terraform init and terraform plan. Both init and plan were successful for all the examples .
Attached terraform init and plan output : [terraform-test-output-20210819.txt](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/files/7017222/terraform-test-output-20210819.txt)
