### PR TITLE
fix: Amend ecs_target network_configuration to work when no ecs_target supplied

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,8 +82,8 @@ resource "aws_cloudwatch_event_target" "this" {
       task_definition_arn = lookup(ecs_target.value, "task_definition_arn", null)
 
       dynamic "network_configuration" {
-        for_each = lookup(each.value.ecs_target, "network_configuration", null) != null ? [
-          each.value.ecs_target.network_configuration
+        for_each = lookup(ecs_target.value, "network_configuration", null) != null ? [
+          ecs_target.value.network_configuration
         ] : []
 
         content {


### PR DESCRIPTION
## Description
This amends the ecs_target dynamic block to look in the correct way as it errored when target does not have an `ecs_target` block.

## Motivation and Context
We found that not supplying an `ecs_target` to a target it complained that couldn't find `network_configuration` exact error:

```
Error: Unsupported attribute

  on .terraform/modules/pipeline_event_bus/main.tf line 85, in resource "aws_cloudwatch_event_target" "this":
  85:         for_each = lookup(each.value.ecs_target, "network_configuration", null) != null ? [
    |----------------
    | each.value is object with 6 attributes

This object does not have an attribute named "ecs_target".
```
This was intermittent and is hard to reproduce, our module usage did not contain an ecs_target configuration
## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects 

I modified the `examples/complete` with following modifications:
* to deploy to `eu-west-2`
* to deploy the `network_configuration` to a VPC and subnet ids
 
I then checked the EventBridge console and checked the details were included here:
![Screenshot 2021-09-21 at 11 33 38](https://user-images.githubusercontent.com/15887464/134157010-62eced84-ef4a-48d7-b785-86f6ab5d6002.png)

We also tested in our terraform module to confirm that we do not see it again.