### PR TITLE
fix: Fixed function name from to_map to tomap

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "aws_cloudwatch_event_rule" "this" {
 resource "aws_cloudwatch_event_target" "this" {
   for_each = var.create && var.create_targets ? {
     for target in local.eventbridge_targets : target.name => target
-  } : to_map({})
+  } : tomap({})
 
   event_bus_name = var.create_bus ? aws_cloudwatch_event_bus.this[0].name : var.bus_name
 


### PR DESCRIPTION
## Description
Using `create_targets = false` causes error:

```
│ Error: Call to unknown function
│
│   on ../../main.tf line 51, in resource "aws_cloudwatch_event_target" "this":
│   51:   } : to_map({})
│
│ There is no function named "to_map". Did you mean "tomap"?
╵
```

## Motivation and Context
Unable to use the parameter because of a bug.

## Breaking Changes
No breaking changes

## How Has This Been Tested?
Add `create_targets  = false` to the example "examples/with-archive" to reproduce the error.
Tested on Terraform v1.0.1

Change tested with examples:
- with-permissions
- default-bus
- with-archive
