### PR TITLE
fix: Amend batch_target to be correct value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,9 @@ resource "aws_cloudwatch_event_target" "this" {
   }
 
   dynamic "batch_target" {
-    for_each = lookup(each.value, "batch_target", null) != null ? [true] : []
+    for_each = lookup(each.value, "batch_target", null) != null ? [
+      each.value.batch_target
+    ] : []
 
     content {
       job_definition = batch_target.value.job_definition


### PR DESCRIPTION
## Description
* Set the value of batch_target to be batch_target rather than true removing: `Can't access attributes on a primitive-typed value (bool)` error

## Motivation and Context
When creating an event target got the error:
```
Error: Unsupported attribute
│ 
│   on .terraform/modules/pipeline_event_bus/main.tf line 116, in resource "aws_cloudwatch_event_target" "this":
│  116:       job_definition = batch_target.value.job_definition
│     ├────────────────
│     │ batch_target.value is true
│ 
│ Can't access attributes on a primitive-typed value (bool).

```

This change fixes this

## Breaking Changes
None

## How Has This Been Tested?
- I have tested using our terraform to confirm it has fixed the issues experienced
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
