### PR TITLE
feat: Enabled tagging for aws_cloudwatch_event_target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+### Feature
+
+* Enabled tagging for resource aws_cloudwatch_event_target so as to tag ecs_target ([#44](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/issues/44) 
+([1b59](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/pull/51/commits/1b593cb33d90c07c58ce7d639e10118a835b223a))
+
+
 ## [1.14.0](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/compare/v1.13.4...v1.14.0) (2022-02-04)
 
 

--- a/main.tf
+++ b/main.tf
@@ -178,6 +178,7 @@ resource "aws_cloudwatch_event_target" "this" {
   }
 
   depends_on = [aws_cloudwatch_event_rule.this]
+  tags = var.tags
 }
 
 resource "aws_cloudwatch_event_archive" "this" {


### PR DESCRIPTION
## Description
Enabled tags for the below 

Resource (In the main.tf file): "aws_cloudwatch_event_target"
Resource name: "this"

We use aws_cloudwatch_event_target resource for tagging the ecs_target

## Motivation and Context
When we began using the repo, we found that one of the resource is yet to be tag enabled. Hence when our internal projects were calling this repo to tag ecs_target, our custom tags were not being added in AWS.

## Breaking Changes
None

## How Has This Been Tested?
This is a basic feature to add tags with no functional change introduced . It has been done as per https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target
