### PR TITLE
fix: Enable run_command_targets support for target

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,9 +72,7 @@ resource "aws_cloudwatch_event_target" "this" {
   input_path = lookup(each.value, "input_path", null)
 
   dynamic "run_command_targets" {
-    for_each = lookup(each.value, "run_command_targets", null) != null ? [
-      each.value.run_command_targets
-    ] : []
+    for_each = try([each.value.run_command_targets], [])
 
     content {
       key    = run_command_targets.value.key

--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,9 @@ resource "aws_cloudwatch_event_target" "this" {
   input_path = lookup(each.value, "input_path", null)
 
   dynamic "run_command_targets" {
-    for_each = lookup(each.value, "run_command_targets", null) != null ? [true] : []
+    for_each = lookup(each.value, "run_command_targets", null) != null ? [
+      each.value.run_command_targets
+    ] : []
 
     content {
       key    = run_command_targets.value.key


### PR DESCRIPTION
## Description
Remove boolean value inside dynamic "run_command_targets" for_each checker and made it usable for inputs.

## Motivation and Context
AWS-RunShellScript event target requires that block for resource creating.
https://github.com/terraform-aws-modules/terraform-aws-eventbridge/issues/48

## Breaking Changes
None.