### PR TITLE
feat: Enable `enable_ecs_managed_tags`

### DIFF
--- a/examples/with-ecs-scheduling/main.tf
+++ b/examples/with-ecs-scheduling/main.tf
@@ -57,9 +57,10 @@ module "eventbridge" {
         attach_role_arn = true
 
         ecs_target = {
-          launch_type         = "FARGATE"
-          task_count          = 1
-          task_definition_arn = aws_ecs_task_definition.hello_world.arn
+          launch_type             = "FARGATE"
+          task_count              = 1
+          task_definition_arn     = aws_ecs_task_definition.hello_world.arn
+          enable_ecs_managed_tags = true
 
           network_configuration = {
             assign_public_ip = true

--- a/main.tf
+++ b/main.tf
@@ -86,11 +86,12 @@ resource "aws_cloudwatch_event_target" "this" {
     ] : []
 
     content {
-      group               = lookup(ecs_target.value, "group", null)
-      launch_type         = lookup(ecs_target.value, "launch_type", null)
-      platform_version    = lookup(ecs_target.value, "platform_version", null)
-      task_count          = lookup(ecs_target.value, "task_count", null)
-      task_definition_arn = lookup(ecs_target.value, "task_definition_arn", null)
+      group                   = lookup(ecs_target.value, "group", null)
+      launch_type             = lookup(ecs_target.value, "launch_type", null)
+      platform_version        = lookup(ecs_target.value, "platform_version", null)
+      task_count              = lookup(ecs_target.value, "task_count", null)
+      task_definition_arn     = lookup(ecs_target.value, "task_definition_arn", null)
+      enable_ecs_managed_tags = lookup(ecs_target.value, "enable_ecs_managed_tags", null)
 
       dynamic "network_configuration" {
         for_each = lookup(ecs_target.value, "network_configuration", null) != null ? [


### PR DESCRIPTION
This enables the setting of the enable_ecs_managed_tags property - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#enable_ecs_managed_tags

## Description
Without this setting, you cannot set up managed tags

## Motivation and Context
I wanted to have the targets be able to have the cluster and service automatically added to each job that ran 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
This is available in the latest major version of the AWS provider 
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
