### PR TITLE
fix: Make it optional to append postfix to the name, connection, or API destination 

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,9 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_api_destinations"></a> [api\_destinations](#input\_api\_destinations) | A map of objects with EventBridge Destination definitions. | `map(any)` | `{}` | no |
+| <a name="input_append_connection_postfix"></a> [append\_connection\_postfix](#input\_append\_connection\_postfix) | Controls whether to append '-connection' to the name of the connection | `bool` | `true` | no |
+| <a name="input_append_destination_postfix"></a> [append\_destination\_postfix](#input\_append\_destination\_postfix) | Controls whether to append '-destination' to the name of the destination | `bool` | `true` | no |
+| <a name="input_append_rule_postfix"></a> [append\_rule\_postfix](#input\_append\_rule\_postfix) | Controls whether to append '-rule' to the name of the rule | `bool` | `true` | no |
 | <a name="input_archives"></a> [archives](#input\_archives) | A map of objects with the EventBridge Archive definitions. | `map(any)` | `{}` | no |
 | <a name="input_attach_api_destination_policy"></a> [attach\_api\_destination\_policy](#input\_attach\_api\_destination\_policy) | Controls whether the API Destination policy should be added to IAM role for EventBridge Target | `bool` | `false` | no |
 | <a name="input_attach_cloudwatch_policy"></a> [attach\_cloudwatch\_policy](#input\_attach\_cloudwatch\_policy) | Controls whether the Cloudwatch policy should be added to IAM role for EventBridge Target | `bool` | `false` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -34,6 +34,8 @@ module "eventbridge" {
 
   attach_cloudwatch_policy = true
   cloudwatch_target_arns   = [aws_cloudwatch_log_group.this.arn]
+  
+  append_rule_postfix = false
 
   attach_ecs_policy = true
   ecs_target_arns   = [aws_ecs_task_definition.hello_world.arn]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -34,7 +34,7 @@ module "eventbridge" {
 
   attach_cloudwatch_policy = true
   cloudwatch_target_arns   = [aws_cloudwatch_log_group.this.arn]
-  
+
   append_rule_postfix = false
 
   attach_ecs_policy = true

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
     for index, rule in var.rules :
     merge(rule, {
       "name" = index
-      "Name" = "${replace(index, "_", "-")}-rule"
+      "Name" = var.append_rule_postfix ? "${replace(index, "_", "-")}-rule" : index
     })
   ])
   eventbridge_targets = flatten([
@@ -11,7 +11,7 @@ locals {
       for target in var.targets[index] :
       merge(target, {
         "rule" = index
-        "Name" = "${replace(index, "_", "-")}-rule"
+        "Name" = var.append_rule_postfix ? "${replace(index, "_", "-")}-rule" : index
       })
     ] if length(var.targets) != 0
   ])
@@ -19,14 +19,14 @@ locals {
     for index, conn in var.connections :
     merge(conn, {
       "name" = index
-      "Name" = "${replace(index, "_", "-")}-connection"
+      "Name" = var.append_connection_postfix ? "${replace(index, "_", "-")}-connection" : index
     })
   ])
   eventbridge_api_destinations = flatten([
     for index, dest in var.api_destinations :
     merge(dest, {
       "name" = index
-      "Name" = "${replace(index, "_", "-")}-destination"
+      "Name" = var.append_destination_postfix ? "${replace(index, "_", "-")}-destination" : index
     })
   ])
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,24 @@ variable "create_role" {
   default     = true
 }
 
+variable "append_rule_postfix" {
+  description = "Controls whether to append '-rule' to the name of the rule"
+  type        = bool
+  default     = true
+}
+
+variable "append_connection_postfix" {
+  description = "Controls whether to append '-connection' to the name of the connection"
+  type        = bool
+  default     = true
+}
+
+variable "append_destination_postfix" {
+  description = "Controls whether to append '-destination' to the name of the destination"
+  type        = bool
+  default     = true
+}
+
 variable "create_bus" {
   description = "Controls whether EventBridge Bus resource should be created"
   type        = bool


### PR DESCRIPTION
## Description
importing of already created rules fail due to the fact that the module appends a postfix to the name of the rule, connection, and API destination.

## Motivation and Context
to make appending "-rule | -connection | -destination" optional we created 3 new bool variable by default it allows for postfix to be appended, when false is passed a value it will stop appending to the name .
an issue has been created #57 

## Breaking Changes
its not a breaking change and it wont cause any compatibility issues .

## How Has This Been Tested?
- we forked this module made the needed changes and then imported our already existing rules without any issues or changes in the plan phase.
- we also updated one example (complete example) and added the **append_rule_postfix = false** to it .
