### PR TITLE
feat: Add discover schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+### [1.14.2](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/compare/v1.14.1...v1.14.2) (2022-07-28)
+
+
+### Bug Fixes
+
+* Make it optional to append postfix to the name, connection, or API destination  ([#58](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/issues/58)) ([980b910](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/commit/980b9108aa34c9354a2e847de03c95b3a012b3d0))
+
 ### [1.14.1](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/compare/v1.14.0...v1.14.1) (2022-06-23)
 
 

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,11 @@ resource "aws_cloudwatch_event_bus" "this" {
   tags = var.tags
 }
 
+resource "aws_schemas_discoverer" "this" {
+  source_arn  = aws_cloudwatch_event_bus.this.arn
+  description = var.discover_description
+}
+
 resource "aws_cloudwatch_event_rule" "this" {
   for_each = { for k, v in local.eventbridge_rules : v.name => v if var.create && var.create_rules }
 

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "aws_cloudwatch_event_bus" "this" {
 }
 
 resource "aws_schemas_discoverer" "this" {
-  source_arn  = aws_cloudwatch_event_bus.this.arn
+  source_arn  = aws_cloudwatch_event_bus.this[0].arn
   description = var.discover_description
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -78,6 +78,12 @@ variable "bus_name" {
   default     = "default"
 }
 
+variable "discover_description" {
+  description = "Disoverer default schema description"
+  type        = string
+  default     = "Auto discover event schemas"
+}
+
 variable "rules" {
   description = "A map of objects with EventBridge Rule definitions."
   type        = map(any)

--- a/variables.tf
+++ b/variables.tf
@@ -79,7 +79,7 @@ variable "bus_name" {
 }
 
 variable "discover_description" {
-  description = "Disoverer default schema description"
+  description = "Discover default schema description"
   type        = string
   default     = "Auto discover event schemas"
 }


### PR DESCRIPTION
## Description
Add default event bus schema discoverer. 

## Motivation and Context
This is change is required since the event bus will not initialised after creation.

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [x] I have executed `pre-commit run -a` on my pull request
