### PR TITLE
fix: Problems found when importing resources previously already created

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -329,6 +329,7 @@ resource "aws_iam_policy" "additional_json" {
   count = local.create_role && var.attach_policy_json ? 1 : 0
 
   name   = local.role_name
+  path   = var.role_path
   policy = var.policy_json
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -41,12 +41,12 @@ output "eventbridge_api_destination_arns" {
 # EventBridge Rule
 output "eventbridge_rule_ids" {
   description = "The EventBridge Rule IDs created"
-  value       = { for k in sort(keys(var.rules)) : k => aws_cloudwatch_event_rule.this[k].id if var.create && var.create_rules }
+  value       = { for k in sort(keys(var.rules)) : k => try(aws_cloudwatch_event_rule.this[k].id, null) if var.create && var.create_rules }
 }
 
 output "eventbridge_rule_arns" {
   description = "The EventBridge Rule ARNs created"
-  value       = { for k in sort(keys(var.rules)) : k => aws_cloudwatch_event_rule.this[k].arn if var.create && var.create_rules }
+  value       = { for k in sort(keys(var.rules)) : k => try(aws_cloudwatch_event_rule.this[k].arn, null) if var.create && var.create_rules }
 }
 
 # IAM Role


### PR DESCRIPTION
## Description
Fixing two issues found:
1) The role_path is the same for role and policy if created by the AWS Console `"/service-role/"`, but when importing and trying do a plan, the plan wants to change the policy path to "/" (default)
2) When importing aws_cloudwatch_event_rule (if you have more than one), the second import fails, because terraform cannot find the resource (yet).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To be able to import the EventBridge rules (and dependencies) that has been created before.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
Since this is hard to test (because depends on real resources to import) I tested locally
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
