### PR TITLE
fix: Fixed inappropriate values for subnets and security_groups in example

### DIFF
--- a/examples/with-ecs-scheduling/main.tf
+++ b/examples/with-ecs-scheduling/main.tf
@@ -64,7 +64,7 @@ module "eventbridge" {
           network_configuration = {
             assign_public_ip = true
             subnets          = data.aws_subnet_ids.default.ids
-            security_groups  = [ data.aws_security_group.default.arn ]
+            security_groups  = [data.aws_security_group.default.arn]
           }
         }
       }

--- a/examples/with-ecs-scheduling/main.tf
+++ b/examples/with-ecs-scheduling/main.tf
@@ -63,8 +63,8 @@ module "eventbridge" {
 
           network_configuration = {
             assign_public_ip = true
-            subnets          = data.aws_subnet_ids.default
-            security_groups  = data.aws_security_group.default
+            subnets          = data.aws_subnet_ids.default.ids
+            security_groups  = [ data.aws_security_group.default.arn ]
           }
         }
       }

--- a/examples/with-ecs-scheduling/main.tf
+++ b/examples/with-ecs-scheduling/main.tf
@@ -89,7 +89,6 @@ resource "aws_ecs_service" "hello_world" {
   name            = "hello_world-${random_pet.this.id}"
   cluster         = module.ecs.ecs_cluster_id
   task_definition = aws_ecs_task_definition.hello_world.arn
-  launch_type     = "FARGATE"
 
   desired_count = 1
 


### PR DESCRIPTION
Fix Inappropriate values for attribute "subnets" and "security_groups"

## Description
Fix Inappropriate values for attribute "subnets" and "security_groups" in the example folder **with-ecs-scheduling**
remove launch_type  FARGATE from ecs service resource as it requires network configuration
## Motivation and Context
current behavior 
Inappropriate value for attribute "subnets": set of string required.
Inappropriate value for attribute "security_groups": set of string required.

## Breaking Changes
No

## How Has This Been Tested?
Tested locally by applying the example 
