### PR TITLE
feat: Add schema discoverer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.76.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ No modules.
 | <a name="input_create_permissions"></a> [create\_permissions](#input\_create\_permissions) | Controls whether EventBridge Permission resources should be created | `bool` | `true` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Controls whether IAM roles should be created | `bool` | `true` | no |
 | <a name="input_create_rules"></a> [create\_rules](#input\_create\_rules) | Controls whether EventBridge Rule resources should be created | `bool` | `true` | no |
-| <a name="input_create_schemas_discoverer"></a> [create\_schemas\_discoverer](#input\_create\_schemas\_discoverer) | Controls wheather default schemas discoverer should be created | `bool` | `false` | no |
+| <a name="input_create_schemas_discoverer"></a> [create\_schemas\_discoverer](#input\_create\_schemas\_discoverer) | Controls whether default schemas discoverer should be created | `bool` | `false` | no |
 | <a name="input_create_targets"></a> [create\_targets](#input\_create\_targets) | Controls whether EventBridge Target resources should be created | `bool` | `true` | no |
 | <a name="input_ecs_target_arns"></a> [ecs\_target\_arns](#input\_ecs\_target\_arns) | The Amazon Resource Name (ARN) of the AWS ECS Tasks you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_kinesis_firehose_target_arns"></a> [kinesis\_firehose\_target\_arns](#input\_kinesis\_firehose\_target\_arns) | The Amazon Resource Name (ARN) of the Kinesis Firehose Delivery Streams you want to use as EventBridge targets | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ No modules.
 | [aws_iam_role.eventbridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.additional_many](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.additional_one](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_schemas_discoverer.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/schemas_discoverer) | resource |
+| [aws_cloudwatch_event_bus.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_event_bus) | data source |
 | [aws_iam_policy.tracing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.additional_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.api_destination](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -453,6 +455,7 @@ No modules.
 | <a name="input_create_permissions"></a> [create\_permissions](#input\_create\_permissions) | Controls whether EventBridge Permission resources should be created | `bool` | `true` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Controls whether IAM roles should be created | `bool` | `true` | no |
 | <a name="input_create_rules"></a> [create\_rules](#input\_create\_rules) | Controls whether EventBridge Rule resources should be created | `bool` | `true` | no |
+| <a name="input_create_schemas_discoverer"></a> [create\_schemas\_discoverer](#input\_create\_schemas\_discoverer) | Controls wheather default schemas discoverer should be created | `bool` | `false` | no |
 | <a name="input_create_targets"></a> [create\_targets](#input\_create\_targets) | Controls whether EventBridge Target resources should be created | `bool` | `true` | no |
 | <a name="input_ecs_target_arns"></a> [ecs\_target\_arns](#input\_ecs\_target\_arns) | The Amazon Resource Name (ARN) of the AWS ECS Tasks you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_kinesis_firehose_target_arns"></a> [kinesis\_firehose\_target\_arns](#input\_kinesis\_firehose\_target\_arns) | The Amazon Resource Name (ARN) of the Kinesis Firehose Delivery Streams you want to use as EventBridge targets | `list(string)` | `[]` | no |
@@ -473,6 +476,7 @@ No modules.
 | <a name="input_role_permissions_boundary"></a> [role\_permissions\_boundary](#input\_role\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the IAM role used by Lambda Function | `string` | `null` | no |
 | <a name="input_role_tags"></a> [role\_tags](#input\_role\_tags) | A map of tags to assign to IAM role | `map(string)` | `{}` | no |
 | <a name="input_rules"></a> [rules](#input\_rules) | A map of objects with EventBridge Rule definitions. | `map(any)` | `{}` | no |
+| <a name="input_schemas_discoverer_description"></a> [schemas\_discoverer\_description](#input\_schemas\_discoverer\_description) | Default schemas discoverer description | `string` | `"Auto schemas discoverer event"` | no |
 | <a name="input_sfn_target_arns"></a> [sfn\_target\_arns](#input\_sfn\_target\_arns) | The Amazon Resource Name (ARN) of the StepFunctions you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_sqs_target_arns"></a> [sqs\_target\_arns](#input\_sqs\_target\_arns) | The Amazon Resource Name (ARN) of the AWS SQS Queues you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -36,6 +36,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../ | n/a |
 | <a name="module_ecs"></a> [ecs](#module\_ecs) | terraform-aws-modules/ecs/aws | ~> 3.0 |
 | <a name="module_eventbridge"></a> [eventbridge](#module\_eventbridge) | ../../ | n/a |
 | <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | ~> 2.0 |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -17,6 +17,8 @@ module "eventbridge" {
   # Some targets are only working with the default bus, so we don't have to create a new one like this:
   # bus_name = "${random_pet.this.id}-bus"
 
+  create_schemas_discoverer = true
+
   attach_tracing_policy = true
 
   attach_kinesis_policy = true
@@ -161,8 +163,9 @@ EOF
   ]
   number_of_policy_jsons = 1
 
-  attach_policy = true
-  policy        = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+  #  # Error can be that maximum 10 policies can be attached to IAM role
+  #  attach_policy = true
+  #  policy        = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
 
   attach_policies    = true
   policies           = ["arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess"]
@@ -192,6 +195,12 @@ EOF
   ###########################
   # END: Additional policies
   ###########################
+}
+
+module "disabled" {
+  source = "../../"
+
+  create = false
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -31,11 +31,24 @@ locals {
   ])
 }
 
+data "aws_cloudwatch_event_bus" "this" {
+  count = (var.create && var.create_bus) || (var.bus_name == "") ? 0 : 1
+
+  name = var.bus_name
+}
+
 resource "aws_cloudwatch_event_bus" "this" {
   count = var.create && var.create_bus ? 1 : 0
 
   name = var.bus_name
   tags = var.tags
+}
+
+resource "aws_schemas_discoverer" "this" {
+  count = var.create && var.create_schemas_discoverer ? 1 : 0
+
+  source_arn  = var.create_bus ? aws_cloudwatch_event_bus.this[0].arn : data.aws_cloudwatch_event_bus.this[0].arn
+  description = var.schemas_discoverer_description
 }
 
 resource "aws_cloudwatch_event_rule" "this" {

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,8 @@ resource "aws_schemas_discoverer" "this" {
 
   source_arn  = var.create_bus ? aws_cloudwatch_event_bus.this[0].arn : data.aws_cloudwatch_event_bus.this[0].arn
   description = var.schemas_discoverer_description
+
+  tags = var.tags
 }
 
 resource "aws_cloudwatch_event_rule" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -71,7 +71,7 @@ variable "create_api_destinations" {
 }
 
 variable "create_schemas_discoverer" {
-  description = "Controls wheather default schemas discoverer should be created"
+  description = "Controls whether default schemas discoverer should be created"
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -70,12 +70,24 @@ variable "create_api_destinations" {
   default     = false
 }
 
+variable "create_schemas_discoverer" {
+  description = "Controls wheather default schemas discoverer should be created"
+  type        = bool
+  default     = false
+}
+
 #######################
 
 variable "bus_name" {
   description = "A unique name for your EventBridge Bus"
   type        = string
   default     = "default"
+}
+
+variable "schemas_discoverer_description" {
+  description = "Default schemas discoverer description"
+  type        = string
+  default     = "Auto schemas discoverer event"
 }
 
 variable "rules" {


### PR DESCRIPTION
## Description
Add default event bus schemas discoverer. This can supersede this [PR](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/pull/60).

Closes #60

## Motivation and Context
This change is required since the event bus will not initialize after the creation

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

this should do the same as before since the schemas discoverer is controlled by `create_schemas_discoverer` and is false by default