### PR TITLE
fix: Outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -35,6 +35,11 @@ output "eventbridge_connection_arns" {
 # EventBridge Destination
 output "eventbridge_api_destination_arns" {
   description = "The EventBridge API Destination ARNs created"
+  value       = { for k, v in aws_cloudwatch_event_api_destination.this : k => v.arn }
+}
+
+output "eventbridge_api_destination_ids" {
+  description = "The EventBridge API Destination IDs created"
   value       = { for k, v in aws_cloudwatch_event_api_destination.this : k => v.id }
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Change mapping output for eventbridge_api_destination_arns to return arn instead of ids. 
Adding eventbridge_api_destination_ids in output to return ids.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The output mapping for eventbridge_api_destination_arns was false, it returns ids instead of arns. 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

If some users are using this output to gather id it'll break the ressources using it, they'll have to use eventbridge_api_destination_ids instead of eventbridge_api_destination_arns. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

Since the modification does not impact the module itself but the ressources using the outputs, no modification was made in the examples. 