### PR TITLE
fix: Wrong value of api destination output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -35,7 +35,7 @@ output "eventbridge_connection_arns" {
 # EventBridge Destination
 output "eventbridge_api_destination_arns" {
   description = "The EventBridge API Destination ARNs created"
-  value       = { for k, v in aws_cloudwatch_event_api_destination.this : k => v.id }
+  value       = { for k, v in aws_cloudwatch_event_api_destination.this : k => v.arn }
 }
 
 # EventBridge Rule


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix wrong value of api destination output.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
