### PR TITLE
chore: Upgrade CI workflow to use non-deprecated runtimes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
           semantic_version: 18.0.0
           extra_plugins: |


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The `Release` workflow is using an old version and hence a [deprecated runtime (Node.js 12)](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). Bumping these workflows will resolve the deprecation warning in the affected workflow.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make sure that CI workflows uses non-deprecated runtimes.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None.
