### PR TITLE
fix: Enable adding event_source_name to an Event Bus to enable receiving events from an SaaS partner

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ No modules.
 | <a name="input_create_schemas_discoverer"></a> [create\_schemas\_discoverer](#input\_create\_schemas\_discoverer) | Controls whether default schemas discoverer should be created | `bool` | `false` | no |
 | <a name="input_create_targets"></a> [create\_targets](#input\_create\_targets) | Controls whether EventBridge Target resources should be created | `bool` | `true` | no |
 | <a name="input_ecs_target_arns"></a> [ecs\_target\_arns](#input\_ecs\_target\_arns) | The Amazon Resource Name (ARN) of the AWS ECS Tasks you want to use as EventBridge targets | `list(string)` | `[]` | no |
+| <a name="input_event_source_name"></a> [event\_source\_name](#input\_event\_source\_name) | The partner event source that the new event bus will be matched with. Must match name. | `string` | `null` | no |
 | <a name="input_kinesis_firehose_target_arns"></a> [kinesis\_firehose\_target\_arns](#input\_kinesis\_firehose\_target\_arns) | The Amazon Resource Name (ARN) of the Kinesis Firehose Delivery Streams you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_kinesis_target_arns"></a> [kinesis\_target\_arns](#input\_kinesis\_target\_arns) | The Amazon Resource Name (ARN) of the Kinesis Streams you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_lambda_target_arns"></a> [lambda\_target\_arns](#input\_lambda\_target\_arns) | The Amazon Resource Name (ARN) of the Lambda Functions you want to use as EventBridge targets | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -40,8 +40,8 @@ data "aws_cloudwatch_event_bus" "this" {
 resource "aws_cloudwatch_event_bus" "this" {
   count = var.create && var.create_bus ? 1 : 0
 
-  name               = var.bus_name
-  event_source_name  = try(var.event_source_name, null)
+  name              = var.bus_name
+  event_source_name = try(var.event_source_name, null)
 
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,9 @@ data "aws_cloudwatch_event_bus" "this" {
 resource "aws_cloudwatch_event_bus" "this" {
   count = var.create && var.create_bus ? 1 : 0
 
-  name = var.bus_name
+  name               = var.bus_name
+  event_source_name  = try(var.event_source_name, null)
+
   tags = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,12 @@ variable "bus_name" {
   default     = "default"
 }
 
+variable "event_source_name" {
+  description = "The partner event source that the new event bus will be matched with. Must match name."
+  type        = string
+  default     = null
+}
+
 variable "schemas_discoverer_description" {
   description = "Default schemas discoverer description"
   type        = string


### PR DESCRIPTION
## Description
To receive [events](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-events.html) from SaaS partner applications and services, you need a partner event source from the partner. Then you can create a partner [event bus](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-bus.html) and match it to the partner event source: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-saas.html

## Motivation and Context
We wanted to add Auth0 as an SaaS partner integration to receive logs from Auth0's log stream.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
I used the modified code to create the needed EventBridge Bus
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
