### PR TITLE
feat: Support for Eventbridge Scheduler Schedules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.80.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -4,15 +4,11 @@ Terraform module to create EventBridge resources.
 
 ## Supported Features
 
-- Creates AWS EventBridge Resources (bus, rules, targets, permissions, connections, destinations)
+- Creates AWS EventBridge Resources (bus, rules, targets, permissions, connections, destinations, schedules)
 - Attach resources to an existing EventBridge bus
 - Support AWS EventBridge Archives and Replays
 - Conditional creation for many types of resources
 - Support IAM policy attachments and various ways to create and attach additional policies
-
-## Feature Roadmap
-
-- Support monitoring usage with Cloudwatch Metrics
 
 ## Usage
 
@@ -486,7 +482,7 @@ No modules.
 | <a name="input_sqs_target_arns"></a> [sqs\_target\_arns](#input\_sqs\_target\_arns) | The Amazon Resource Name (ARN) of the AWS SQS Queues you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |
 | <a name="input_targets"></a> [targets](#input\_targets) | A map of objects with EventBridge Target definitions. | `any` | `{}` | no |
-| <a name="input_trusted_entities"></a> [trusted\_entities](#input\_trusted\_entities) | Step Function additional trusted entities for assuming roles (trust relationship) | `list(string)` | `[]` | no |
+| <a name="input_trusted_entities"></a> [trusted\_entities](#input\_trusted\_entities) | Additional trusted entities for assuming roles (trust relationship) | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Terraform module to create EventBridge resources.
 
 ## Supported Features
 
-- Creates AWS EventBridge Resources (bus, rules, targets, permissions, connections, destinations, schedules)
+- Creates AWS EventBridge Resources (bus, rules, targets, permissions, connections, destinations, schedules and schedule groups)
 - Attach resources to an existing EventBridge bus
 - Support AWS EventBridge Archives and Replays
 - Conditional creation for many types of resources
@@ -226,6 +226,29 @@ module "eventbridge" {
 }
 ```
 
+### EventBridge Scheduler which triggers Lambda Function
+
+```hcl
+module "eventbridge" {
+  source = "terraform-aws-modules/eventbridge/aws"
+
+  bus_name = "example" # "default" bus already support schedule_expression in rules
+
+  attach_lambda_policy = true
+  lambda_target_arns   = ["arn:aws:lambda:us-east-1:135367859851:function:resolved-penguin-lambda"]
+
+  schedules = {
+    lambda-cron = {
+      description         = "Trigger for a Lambda"
+      schedule_expression = "rate(1 day)"
+      timezone            = "Europe/London"
+      arn                 = "arn:aws:lambda:us-east-1:135367859851:function:resolved-penguin-lambda"
+      input               = jsonencode({ "job" : "cron-by-rate" })
+    }
+  }
+}
+```
+
 ### EventBridge API Destination
 
 ```hcl
@@ -320,6 +343,8 @@ module "eventbridge" {
   create_role             = false  # to control creation of the IAM role and policies required for EventBridge
   create_connections      = false  # to control creation of EventBridge Connection resources
   create_api_destinations = false  # to control creation of EventBridge Destination resources
+  create_schedule_groups  = false  # to control creation of EventBridge Schedule Group resources
+  create_schedules        = false  # to control creation of EventBridge Schedule resources
 
   attach_cloudwatch_policy       = false
   attach_ecs_policy              = false
@@ -342,8 +367,9 @@ module "eventbridge" {
 * [Using Default Bus](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/tree/master/examples/default-bus) - Creates resources in the `default` bus.
 * [Archive](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/tree/master/examples/with-archive) - EventBridge Archives resources in various configurations.
 * [Permissions](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/tree/master/examples/with-permissions) - Controls permissions to EventBridge.
+* [Scheduler](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/tree/master/examples/with-schedules) - EventBridge Scheduler which works with any bus (recommended way).
 * [ECS Scheduling Events](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/tree/master/examples/with-ecs-scheduling) - Use default bus to schedule events on ECS.
-* [Lambda Scheduling Events](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/tree/master/examples/with-lambda-scheduling) - Trigger Lambda functions on schedule.
+* [Lambda Scheduling Events](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/tree/master/examples/with-lambda-scheduling) - Trigger Lambda functions on schedule (works only with default bus).
 * [API Destination](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/tree/master/examples/with-api-destination) - Control access to EventBridge using API destinations.
 
 
@@ -406,6 +432,7 @@ No modules.
 | [aws_iam_role_policy_attachment.additional_many](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.additional_one](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_scheduler_schedule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/scheduler_schedule) | resource |
+| [aws_scheduler_schedule_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/scheduler_schedule_group) | resource |
 | [aws_schemas_discoverer.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/schemas_discoverer) | resource |
 | [aws_cloudwatch_event_bus.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_event_bus) | data source |
 | [aws_iam_policy.tracing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
@@ -429,6 +456,7 @@ No modules.
 | <a name="input_append_connection_postfix"></a> [append\_connection\_postfix](#input\_append\_connection\_postfix) | Controls whether to append '-connection' to the name of the connection | `bool` | `true` | no |
 | <a name="input_append_destination_postfix"></a> [append\_destination\_postfix](#input\_append\_destination\_postfix) | Controls whether to append '-destination' to the name of the destination | `bool` | `true` | no |
 | <a name="input_append_rule_postfix"></a> [append\_rule\_postfix](#input\_append\_rule\_postfix) | Controls whether to append '-rule' to the name of the rule | `bool` | `true` | no |
+| <a name="input_append_schedule_group_postfix"></a> [append\_schedule\_group\_postfix](#input\_append\_schedule\_group\_postfix) | Controls whether to append '-group' to the name of the schedule group | `bool` | `true` | no |
 | <a name="input_append_schedule_postfix"></a> [append\_schedule\_postfix](#input\_append\_schedule\_postfix) | Controls whether to append '-schedule' to the name of the schedule | `bool` | `true` | no |
 | <a name="input_archives"></a> [archives](#input\_archives) | A map of objects with the EventBridge Archive definitions. | `map(any)` | `{}` | no |
 | <a name="input_attach_api_destination_policy"></a> [attach\_api\_destination\_policy](#input\_attach\_api\_destination\_policy) | Controls whether the API Destination policy should be added to IAM role for EventBridge Target | `bool` | `false` | no |
@@ -457,6 +485,7 @@ No modules.
 | <a name="input_create_permissions"></a> [create\_permissions](#input\_create\_permissions) | Controls whether EventBridge Permission resources should be created | `bool` | `true` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Controls whether IAM roles should be created | `bool` | `true` | no |
 | <a name="input_create_rules"></a> [create\_rules](#input\_create\_rules) | Controls whether EventBridge Rule resources should be created | `bool` | `true` | no |
+| <a name="input_create_schedule_groups"></a> [create\_schedule\_groups](#input\_create\_schedule\_groups) | Controls whether EventBridge Schedule Group resources should be created | `bool` | `true` | no |
 | <a name="input_create_schedules"></a> [create\_schedules](#input\_create\_schedules) | Controls whether EventBridge Schedule resources should be created | `bool` | `true` | no |
 | <a name="input_create_schemas_discoverer"></a> [create\_schemas\_discoverer](#input\_create\_schemas\_discoverer) | Controls whether default schemas discoverer should be created | `bool` | `false` | no |
 | <a name="input_create_targets"></a> [create\_targets](#input\_create\_targets) | Controls whether EventBridge Target resources should be created | `bool` | `true` | no |
@@ -480,6 +509,8 @@ No modules.
 | <a name="input_role_permissions_boundary"></a> [role\_permissions\_boundary](#input\_role\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the IAM role used by EventBridge | `string` | `null` | no |
 | <a name="input_role_tags"></a> [role\_tags](#input\_role\_tags) | A map of tags to assign to IAM role | `map(string)` | `{}` | no |
 | <a name="input_rules"></a> [rules](#input\_rules) | A map of objects with EventBridge Rule definitions. | `map(any)` | `{}` | no |
+| <a name="input_schedule_group_timeouts"></a> [schedule\_group\_timeouts](#input\_schedule\_group\_timeouts) | A map of objects with EventBridge Schedule Group create and delete timeouts. | `map(string)` | `{}` | no |
+| <a name="input_schedule_groups"></a> [schedule\_groups](#input\_schedule\_groups) | A map of objects with EventBridge Schedule Group definitions. | `any` | `{}` | no |
 | <a name="input_schedules"></a> [schedules](#input\_schedules) | A map of objects with EventBridge Schedule definitions. | `map(any)` | `{}` | no |
 | <a name="input_schemas_discoverer_description"></a> [schemas\_discoverer\_description](#input\_schemas\_discoverer\_description) | Default schemas discoverer description | `string` | `"Auto schemas discoverer event"` | no |
 | <a name="input_sfn_target_arns"></a> [sfn\_target\_arns](#input\_sfn\_target\_arns) | The Amazon Resource Name (ARN) of the StepFunctions you want to use as EventBridge targets | `list(string)` | `[]` | no |
@@ -493,18 +524,22 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_eventbridge_api_destination_arns"></a> [eventbridge\_api\_destination\_arns](#output\_eventbridge\_api\_destination\_arns) | The EventBridge API Destination ARNs created |
-| <a name="output_eventbridge_archive_arns"></a> [eventbridge\_archive\_arns](#output\_eventbridge\_archive\_arns) | The EventBridge Archive Arns created |
-| <a name="output_eventbridge_bus_arn"></a> [eventbridge\_bus\_arn](#output\_eventbridge\_bus\_arn) | The EventBridge Bus Arn |
+| <a name="output_eventbridge_api_destination_arns"></a> [eventbridge\_api\_destination\_arns](#output\_eventbridge\_api\_destination\_arns) | The EventBridge API Destination ARNs |
+| <a name="output_eventbridge_archive_arns"></a> [eventbridge\_archive\_arns](#output\_eventbridge\_archive\_arns) | The EventBridge Archive ARNs |
+| <a name="output_eventbridge_bus_arn"></a> [eventbridge\_bus\_arn](#output\_eventbridge\_bus\_arn) | The EventBridge Bus ARN |
 | <a name="output_eventbridge_bus_name"></a> [eventbridge\_bus\_name](#output\_eventbridge\_bus\_name) | The EventBridge Bus Name |
-| <a name="output_eventbridge_connection_arns"></a> [eventbridge\_connection\_arns](#output\_eventbridge\_connection\_arns) | The EventBridge Connection Arns created |
-| <a name="output_eventbridge_connection_ids"></a> [eventbridge\_connection\_ids](#output\_eventbridge\_connection\_ids) | The EventBridge Connection IDs created |
-| <a name="output_eventbridge_permission_ids"></a> [eventbridge\_permission\_ids](#output\_eventbridge\_permission\_ids) | The EventBridge Permission Arns created |
+| <a name="output_eventbridge_connection_arns"></a> [eventbridge\_connection\_arns](#output\_eventbridge\_connection\_arns) | The EventBridge Connection Arns |
+| <a name="output_eventbridge_connection_ids"></a> [eventbridge\_connection\_ids](#output\_eventbridge\_connection\_ids) | The EventBridge Connection IDs |
+| <a name="output_eventbridge_permission_ids"></a> [eventbridge\_permission\_ids](#output\_eventbridge\_permission\_ids) | The EventBridge Permission IDs |
 | <a name="output_eventbridge_role_arn"></a> [eventbridge\_role\_arn](#output\_eventbridge\_role\_arn) | The ARN of the IAM role created for EventBridge |
 | <a name="output_eventbridge_role_name"></a> [eventbridge\_role\_name](#output\_eventbridge\_role\_name) | The name of the IAM role created for EventBridge |
-| <a name="output_eventbridge_rule_arns"></a> [eventbridge\_rule\_arns](#output\_eventbridge\_rule\_arns) | The EventBridge Rule ARNs created |
-| <a name="output_eventbridge_rule_ids"></a> [eventbridge\_rule\_ids](#output\_eventbridge\_rule\_ids) | The EventBridge Rule IDs created |
+| <a name="output_eventbridge_rule_arns"></a> [eventbridge\_rule\_arns](#output\_eventbridge\_rule\_arns) | The EventBridge Rule ARNs |
+| <a name="output_eventbridge_rule_ids"></a> [eventbridge\_rule\_ids](#output\_eventbridge\_rule\_ids) | The EventBridge Rule IDs |
 | <a name="output_eventbridge_schedule_arns"></a> [eventbridge\_schedule\_arns](#output\_eventbridge\_schedule\_arns) | The EventBridge Schedule ARNs created |
+| <a name="output_eventbridge_schedule_group_arns"></a> [eventbridge\_schedule\_group\_arns](#output\_eventbridge\_schedule\_group\_arns) | The EventBridge Schedule Group ARNs |
+| <a name="output_eventbridge_schedule_group_ids"></a> [eventbridge\_schedule\_group\_ids](#output\_eventbridge\_schedule\_group\_ids) | The EventBridge Schedule Group IDs |
+| <a name="output_eventbridge_schedule_group_states"></a> [eventbridge\_schedule\_group\_states](#output\_eventbridge\_schedule\_group\_states) | The EventBridge Schedule Group states |
+| <a name="output_eventbridge_schedule_ids"></a> [eventbridge\_schedule\_ids](#output\_eventbridge\_schedule\_ids) | The EventBridge Schedule IDs created |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ No modules.
 | [aws_iam_role.eventbridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.additional_many](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.additional_one](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_scheduler_schedule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/scheduler_schedule) | resource |
 | [aws_schemas_discoverer.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/schemas_discoverer) | resource |
 | [aws_cloudwatch_event_bus.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_event_bus) | data source |
 | [aws_iam_policy.tracing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
@@ -429,6 +430,7 @@ No modules.
 | <a name="input_append_connection_postfix"></a> [append\_connection\_postfix](#input\_append\_connection\_postfix) | Controls whether to append '-connection' to the name of the connection | `bool` | `true` | no |
 | <a name="input_append_destination_postfix"></a> [append\_destination\_postfix](#input\_append\_destination\_postfix) | Controls whether to append '-destination' to the name of the destination | `bool` | `true` | no |
 | <a name="input_append_rule_postfix"></a> [append\_rule\_postfix](#input\_append\_rule\_postfix) | Controls whether to append '-rule' to the name of the rule | `bool` | `true` | no |
+| <a name="input_append_schedule_postfix"></a> [append\_schedule\_postfix](#input\_append\_schedule\_postfix) | Controls whether to append '-schedule' to the name of the schedule | `bool` | `true` | no |
 | <a name="input_archives"></a> [archives](#input\_archives) | A map of objects with the EventBridge Archive definitions. | `map(any)` | `{}` | no |
 | <a name="input_attach_api_destination_policy"></a> [attach\_api\_destination\_policy](#input\_attach\_api\_destination\_policy) | Controls whether the API Destination policy should be added to IAM role for EventBridge Target | `bool` | `false` | no |
 | <a name="input_attach_cloudwatch_policy"></a> [attach\_cloudwatch\_policy](#input\_attach\_cloudwatch\_policy) | Controls whether the Cloudwatch policy should be added to IAM role for EventBridge Target | `bool` | `false` | no |
@@ -455,6 +457,7 @@ No modules.
 | <a name="input_create_permissions"></a> [create\_permissions](#input\_create\_permissions) | Controls whether EventBridge Permission resources should be created | `bool` | `true` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Controls whether IAM roles should be created | `bool` | `true` | no |
 | <a name="input_create_rules"></a> [create\_rules](#input\_create\_rules) | Controls whether EventBridge Rule resources should be created | `bool` | `true` | no |
+| <a name="input_create_schedules"></a> [create\_schedules](#input\_create\_schedules) | Controls whether EventBridge Schedule resources should be created | `bool` | `true` | no |
 | <a name="input_create_schemas_discoverer"></a> [create\_schemas\_discoverer](#input\_create\_schemas\_discoverer) | Controls whether default schemas discoverer should be created | `bool` | `false` | no |
 | <a name="input_create_targets"></a> [create\_targets](#input\_create\_targets) | Controls whether EventBridge Target resources should be created | `bool` | `true` | no |
 | <a name="input_ecs_target_arns"></a> [ecs\_target\_arns](#input\_ecs\_target\_arns) | The Amazon Resource Name (ARN) of the AWS ECS Tasks you want to use as EventBridge targets | `list(string)` | `[]` | no |
@@ -477,6 +480,7 @@ No modules.
 | <a name="input_role_permissions_boundary"></a> [role\_permissions\_boundary](#input\_role\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the IAM role used by EventBridge | `string` | `null` | no |
 | <a name="input_role_tags"></a> [role\_tags](#input\_role\_tags) | A map of tags to assign to IAM role | `map(string)` | `{}` | no |
 | <a name="input_rules"></a> [rules](#input\_rules) | A map of objects with EventBridge Rule definitions. | `map(any)` | `{}` | no |
+| <a name="input_schedules"></a> [schedules](#input\_schedules) | A map of objects with EventBridge Schedule definitions. | `map(any)` | `{}` | no |
 | <a name="input_schemas_discoverer_description"></a> [schemas\_discoverer\_description](#input\_schemas\_discoverer\_description) | Default schemas discoverer description | `string` | `"Auto schemas discoverer event"` | no |
 | <a name="input_sfn_target_arns"></a> [sfn\_target\_arns](#input\_sfn\_target\_arns) | The Amazon Resource Name (ARN) of the StepFunctions you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_sqs_target_arns"></a> [sqs\_target\_arns](#input\_sqs\_target\_arns) | The Amazon Resource Name (ARN) of the AWS SQS Queues you want to use as EventBridge targets | `list(string)` | `[]` | no |
@@ -499,6 +503,7 @@ No modules.
 | <a name="output_eventbridge_role_name"></a> [eventbridge\_role\_name](#output\_eventbridge\_role\_name) | The name of the IAM role created for EventBridge |
 | <a name="output_eventbridge_rule_arns"></a> [eventbridge\_rule\_arns](#output\_eventbridge\_rule\_arns) | The EventBridge Rule ARNs created |
 | <a name="output_eventbridge_rule_ids"></a> [eventbridge\_rule\_ids](#output\_eventbridge\_rule\_ids) | The EventBridge Rule IDs created |
+| <a name="output_eventbridge_schedule_arns"></a> [eventbridge\_schedule\_arns](#output\_eventbridge\_schedule\_arns) | The EventBridge Schedule ARNs created |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/api-gateway-event-source/main.tf
+++ b/examples/api-gateway-event-source/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "ap-southeast-1"
+  region = "eu-west-1"
 
   # Make it faster by skipping something
   skip_metadata_api_check     = true

--- a/examples/api-gateway-event-source/main.tf
+++ b/examples/api-gateway-event-source/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "ap-southeast-1"
+  region = "eu-west-1"
 
   # Make it faster by skipping something
   skip_metadata_api_check     = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/default-bus/main.tf
+++ b/examples/default-bus/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "ap-southeast-1"
+  region = "eu-west-1"
 
   # Make it faster by skipping something
   skip_metadata_api_check     = true

--- a/examples/default-bus/main.tf
+++ b/examples/default-bus/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-api-destination/main.tf
+++ b/examples/with-api-destination/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "ap-southeast-1"
+  region = "eu-west-1"
 
   # Make it faster by skipping something
   skip_metadata_api_check     = true

--- a/examples/with-api-destination/main.tf
+++ b/examples/with-api-destination/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-archive/main.tf
+++ b/examples/with-archive/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "ap-southeast-1"
+  region = "eu-west-1"
 
   # Make it faster by skipping something
   skip_metadata_api_check     = true

--- a/examples/with-archive/main.tf
+++ b/examples/with-archive/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-ecs-scheduling/main.tf
+++ b/examples/with-ecs-scheduling/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "ap-southeast-1"
+  region = "eu-west-1"
 
   # Make it faster by skipping something
   skip_metadata_api_check     = true

--- a/examples/with-ecs-scheduling/main.tf
+++ b/examples/with-ecs-scheduling/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-lambda-scheduling/main.tf
+++ b/examples/with-lambda-scheduling/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "ap-southeast-1"
+  region = "eu-west-1"
 
   # Make it faster by skipping something
   skip_metadata_api_check     = true

--- a/examples/with-lambda-scheduling/main.tf
+++ b/examples/with-lambda-scheduling/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-permissions/main.tf
+++ b/examples/with-permissions/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "ap-southeast-1"
+  region = "eu-west-1"
 
   # Make it faster by skipping something
   skip_metadata_api_check     = true

--- a/examples/with-permissions/main.tf
+++ b/examples/with-permissions/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-schedules/README.md
+++ b/examples/with-schedules/README.md
@@ -36,7 +36,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_eventbridge"></a> [eventbridge](#module\_eventbridge) | ../../ | n/a |
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | ~> 4.0 |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | ~> 5.0 |
 
 ## Resources
 
@@ -53,7 +53,11 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_eventbridge_schedule_arns"></a> [eventbridge\_schedule\_arns](#output\_eventbridge\_schedule\_arns) | The EventBridge Schedule ARNs |
+| <a name="output_eventbridge_schedule_arns"></a> [eventbridge\_schedule\_arns](#output\_eventbridge\_schedule\_arns) | The EventBridge Schedule ARNs created |
+| <a name="output_eventbridge_schedule_group_arns"></a> [eventbridge\_schedule\_group\_arns](#output\_eventbridge\_schedule\_group\_arns) | The EventBridge Schedule Group ARNs |
+| <a name="output_eventbridge_schedule_group_ids"></a> [eventbridge\_schedule\_group\_ids](#output\_eventbridge\_schedule\_group\_ids) | The EventBridge Schedule Group IDs |
+| <a name="output_eventbridge_schedule_group_states"></a> [eventbridge\_schedule\_group\_states](#output\_eventbridge\_schedule\_group\_states) | The EventBridge Schedule Group states |
+| <a name="output_eventbridge_schedule_ids"></a> [eventbridge\_schedule\_ids](#output\_eventbridge\_schedule\_ids) | The EventBridge Schedule IDs created |
 | <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn) | The ARN of the Lambda Function |
 | <a name="output_lambda_function_name"></a> [lambda\_function\_name](#output\_lambda\_function\_name) | The name of the Lambda Function |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/with-schedules/README.md
+++ b/examples/with-schedules/README.md
@@ -1,0 +1,59 @@
+# EventBridge Lambda & Scheduler Schedules Example
+
+Configuration in this directory creates EventBridge resource configuration including an Lambda service.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name                                                                      | Version   |
+| ------------------------------------------------------------------------- | --------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 4.7    |
+| <a name="requirement_null"></a> [null](#requirement\_null)                | >= 2.0    |
+| <a name="requirement_random"></a> [random](#requirement\_random)          | >= 3.0    |
+
+## Providers
+
+| Name                                                       | Version |
+| ---------------------------------------------------------- | ------- |
+| <a name="provider_null"></a> [null](#provider\_null)       | >= 2.0  |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0  |
+
+## Modules
+
+| Name                                                                  | Source                           | Version |
+| --------------------------------------------------------------------- | -------------------------------- | ------- |
+| <a name="module_eventbridge"></a> [eventbridge](#module\_eventbridge) | ../../                           | n/a     |
+| <a name="module_lambda"></a> [lambda](#module\_lambda)                | terraform-aws-modules/lambda/aws | ~> 2.0  |
+
+## Resources
+
+| Name                                                                                                                    | Type     |
+| ----------------------------------------------------------------------------------------------------------------------- | -------- |
+| [null_resource.download_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet)                   | resource |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name                                                                                                    | Description                     |
+| ------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| <a name="output_eventbridge_rule_arns"></a> [eventbridge\_rule\_arns](#output\_eventbridge\_rule\_arns) | The EventBridge Rule ARNs       |
+| <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn)       | The ARN of the Lambda Function  |
+| <a name="output_lambda_function_name"></a> [lambda\_function\_name](#output\_lambda\_function\_name)    | The name of the Lambda Function |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/with-schedules/README.md
+++ b/examples/with-schedules/README.md
@@ -1,6 +1,6 @@
-# EventBridge Lambda & Scheduler Schedules Example
+# EventBridge Scheduler with Schedule Groups Example
 
-Configuration in this directory creates EventBridge resource configuration including an Lambda service.
+Configuration in this directory creates EventBridge Scheduler resources which triggers Lambda Function.
 
 ## Usage
 

--- a/examples/with-schedules/README.md
+++ b/examples/with-schedules/README.md
@@ -19,8 +19,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
@@ -36,7 +36,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_eventbridge"></a> [eventbridge](#module\_eventbridge) | ../../ | n/a |
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | ~> 2.0 |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | ~> 4.0 |
 
 ## Resources
 

--- a/examples/with-schedules/README.md
+++ b/examples/with-schedules/README.md
@@ -17,33 +17,33 @@ Note that this example may create resources which cost money. Run `terraform des
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-| Name                                                                      | Version   |
-| ------------------------------------------------------------------------- | --------- |
+| Name | Version |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 4.7    |
-| <a name="requirement_null"></a> [null](#requirement\_null)                | >= 2.0    |
-| <a name="requirement_random"></a> [random](#requirement\_random)          | >= 3.0    |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
-| Name                                                       | Version |
-| ---------------------------------------------------------- | ------- |
-| <a name="provider_null"></a> [null](#provider\_null)       | >= 2.0  |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0  |
+| Name | Version |
+|------|---------|
+| <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
 
-| Name                                                                  | Source                           | Version |
-| --------------------------------------------------------------------- | -------------------------------- | ------- |
-| <a name="module_eventbridge"></a> [eventbridge](#module\_eventbridge) | ../../                           | n/a     |
-| <a name="module_lambda"></a> [lambda](#module\_lambda)                | terraform-aws-modules/lambda/aws | ~> 2.0  |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_eventbridge"></a> [eventbridge](#module\_eventbridge) | ../../ | n/a |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | ~> 2.0 |
 
 ## Resources
 
-| Name                                                                                                                    | Type     |
-| ----------------------------------------------------------------------------------------------------------------------- | -------- |
+| Name | Type |
+|------|------|
 | [null_resource.download_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet)                   | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
@@ -51,9 +51,9 @@ No inputs.
 
 ## Outputs
 
-| Name                                                                                                    | Description                     |
-| ------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| <a name="output_eventbridge_rule_arns"></a> [eventbridge\_rule\_arns](#output\_eventbridge\_rule\_arns) | The EventBridge Rule ARNs       |
-| <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn)       | The ARN of the Lambda Function  |
-| <a name="output_lambda_function_name"></a> [lambda\_function\_name](#output\_lambda\_function\_name)    | The name of the Lambda Function |
+| Name | Description |
+|------|-------------|
+| <a name="output_eventbridge_schedule_arns"></a> [eventbridge\_schedule\_arns](#output\_eventbridge\_schedule\_arns) | The EventBridge Schedule ARNs |
+| <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn) | The ARN of the Lambda Function |
+| <a name="output_lambda_function_name"></a> [lambda\_function\_name](#output\_lambda\_function\_name) | The name of the Lambda Function |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/with-schedules/main.tf
+++ b/examples/with-schedules/main.tf
@@ -1,0 +1,73 @@
+provider "aws" {
+  region = "ap-southeast-1"
+
+  # Make it faster by skipping something
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+}
+
+module "eventbridge" {
+  source = "../../"
+
+  create_bus = false
+
+  trusted_entities = ["scheduler.amazonaws.com"]
+
+  schedules = {
+    lambda-cron = {
+      description         = "Trigger for a Lambda"
+      schedule_expression = "cron(0 1 * * ? *)"
+      timezone            = "Europe/London"
+      target_id           = module.lambda.lambda_function_arn
+    }
+  }
+}
+
+##################
+# Extra resources
+##################
+
+resource "random_pet" "this" {
+  length = 2
+}
+
+#############################################
+# Using packaged function from Lambda module
+#############################################
+
+module "lambda" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "~> 2.0"
+
+  function_name = "${random_pet.this.id}-lambda"
+  handler       = "index.lambda_handler"
+  runtime       = "python3.8"
+
+  create_package         = false
+  local_existing_package = local.downloaded
+
+  create_current_version_allowed_triggers = false
+  allowed_triggers = {
+    ScanAmiRule = {
+      principal  = "schedules.amazonaws.com"
+      source_arn = module.eventbridge.eventbridge_schedule_arns["lambda-cron"]
+    }
+  }
+}
+
+locals {
+  package_url = "https://raw.githubusercontent.com/terraform-aws-modules/terraform-aws-lambda/master/examples/fixtures/python3.8-zip/existing_package.zip"
+  downloaded  = "downloaded_package_${md5(local.package_url)}.zip"
+}
+
+resource "null_resource" "download_package" {
+  triggers = {
+    downloaded = local.downloaded
+  }
+
+  provisioner "local-exec" {
+    command = "curl -L -o ${local.downloaded} ${local.package_url}"
+  }
+}

--- a/examples/with-schedules/main.tf
+++ b/examples/with-schedules/main.tf
@@ -20,7 +20,8 @@ module "eventbridge" {
       description         = "Trigger for a Lambda"
       schedule_expression = "cron(0 1 * * ? *)"
       timezone            = "Europe/London"
-      target_id           = module.lambda.lambda_function_arn
+      arn                 = module.lambda.lambda_function_arn
+      input               = jsonencode({ "job" : "cron-by-rate" })
     }
   }
 }

--- a/examples/with-schedules/main.tf
+++ b/examples/with-schedules/main.tf
@@ -15,6 +15,9 @@ module "eventbridge" {
 
   trusted_entities = ["scheduler.amazonaws.com"]
 
+  attach_lambda_policy = true
+  lambda_target_arns   = [module.lambda.lambda_function_arn]
+
   schedules = {
     lambda-cron = {
       description         = "Trigger for a Lambda"
@@ -40,7 +43,7 @@ resource "random_pet" "this" {
 
 module "lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 2.0"
+  version = "~> 4.0"
 
   function_name = "${random_pet.this.id}-lambda"
   handler       = "index.lambda_handler"
@@ -49,10 +52,12 @@ module "lambda" {
   create_package         = false
   local_existing_package = local.downloaded
 
+  trusted_entities = ["scheduler.amazonaws.com"]
+
   create_current_version_allowed_triggers = false
   allowed_triggers = {
     ScanAmiRule = {
-      principal  = "schedules.amazonaws.com"
+      principal  = "scheduler.amazonaws.com"
       source_arn = module.eventbridge.eventbridge_schedule_arns["lambda-cron"]
     }
   }

--- a/examples/with-schedules/outputs.tf
+++ b/examples/with-schedules/outputs.tf
@@ -1,8 +1,31 @@
-output "eventbridge_schedule_arns" {
-  description = "The EventBridge Schedule ARNs"
+# EventBridge Schedule Group
+output "eventbridge_schedule_group_ids" {
+  description = "The EventBridge Schedule Group IDs"
   value       = module.eventbridge.eventbridge_schedule_arns
 }
 
+output "eventbridge_schedule_group_arns" {
+  description = "The EventBridge Schedule Group ARNs"
+  value       = module.eventbridge.eventbridge_schedule_group_arns
+}
+
+output "eventbridge_schedule_group_states" {
+  description = "The EventBridge Schedule Group states"
+  value       = module.eventbridge.eventbridge_schedule_group_states
+}
+
+# EventBridge Schedule
+output "eventbridge_schedule_ids" {
+  description = "The EventBridge Schedule IDs created"
+  value       = module.eventbridge.eventbridge_schedule_ids
+}
+
+output "eventbridge_schedule_arns" {
+  description = "The EventBridge Schedule ARNs created"
+  value       = module.eventbridge.eventbridge_schedule_arns
+}
+
+# Lambda Function
 output "lambda_function_arn" {
   description = "The ARN of the Lambda Function"
   value       = module.lambda.lambda_function_arn

--- a/examples/with-schedules/outputs.tf
+++ b/examples/with-schedules/outputs.tf
@@ -1,0 +1,14 @@
+output "eventbridge_schedule_arns" {
+  description = "The EventBridge Schedule ARNs"
+  value       = module.eventbridge.eventbridge_schedule_arns
+}
+
+output "lambda_function_arn" {
+  description = "The ARN of the Lambda Function"
+  value       = module.lambda.lambda_function_arn
+}
+
+output "lambda_function_name" {
+  description = "The name of the Lambda Function"
+  value       = module.lambda.lambda_function_name
+}

--- a/examples/with-schedules/versions.tf
+++ b/examples/with-schedules/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.7"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
+  }
+}

--- a/examples/with-schedules/versions.tf
+++ b/examples/with-schedules/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7"
+      version = ">= 4.64"
     }
     random = {
       source  = "hashicorp/random"

--- a/iam.tf
+++ b/iam.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = distinct(concat(["events.amazonaws.com"], var.trusted_entities))
+      identifiers = distinct(concat(["events.amazonaws.com"], var.trusted_entities, length(keys(var.schedules)) > 0 && var.create_schedules ? ["scheduler.amazonaws.com"] : []))
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -384,7 +384,7 @@ resource "aws_scheduler_schedule" "this" {
   schedule_expression_timezone = lookup(each.value, "timezone", null)
 
   target {
-    arn      = lookup(each.value, "target_id", null)
+    arn      = lookup(each.value, "arn", null)
     input    = lookup(each.value, "input", null)
     role_arn = can(length(each.value.role_arn) > 0) ? each.value.role_arn : aws_iam_role.eventbridge[0].arn
 

--- a/main.tf
+++ b/main.tf
@@ -374,14 +374,23 @@ resource "aws_scheduler_schedule" "this" {
   name        = each.value.Name
   name_prefix = lookup(each.value, "name_prefix", null)
   description = lookup(each.value, "description", null)
+  group_name  = lookup(each.value, "group_name", null)
+
+  start_date = lookup(each.value, "start_date", null)
+  end_date   = lookup(each.value, "end_date", null)
+
+  kms_key_arn = lookup(each.value, "kms_key_arn", null)
+
+  schedule_expression          = lookup(each.value, "schedule_expression", null)
+  schedule_expression_timezone = lookup(each.value, "timezone", null)
+
+  state = lookup(each.value, "enabled", true) ? "ENABLED" : "DISABLED"
+
 
   flexible_time_window {
     maximum_window_in_minutes = lookup(each.value, "maximum_window_in_minutes", null)
     mode                      = lookup(each.value, "use_flexible_time_window", false) ? "FLEXIBLE" : "OFF"
   }
-
-  schedule_expression          = lookup(each.value, "schedule_expression", null)
-  schedule_expression_timezone = lookup(each.value, "timezone", null)
 
   target {
     arn      = lookup(each.value, "arn", null)

--- a/outputs.tf
+++ b/outputs.tf
@@ -49,6 +49,12 @@ output "eventbridge_rule_arns" {
   value       = { for k in sort(keys(var.rules)) : k => try(aws_cloudwatch_event_rule.this[k].arn, null) if var.create && var.create_rules }
 }
 
+# EventBridge Schedule
+output "eventbridge_schedule_arns" {
+  description = "The EventBridge Schedule ARNs created"
+  value       = { for k in sort(keys(var.schedules)) : k => try(aws_scheduler_schedule.this[k].arn, null) if var.create && var.create_schedules }
+}
+
 # IAM Role
 output "eventbridge_role_arn" {
   description = "The ARN of the IAM role created for EventBridge"
@@ -58,9 +64,4 @@ output "eventbridge_role_arn" {
 output "eventbridge_role_name" {
   description = "The name of the IAM role created for EventBridge"
   value       = try(aws_iam_role.eventbridge[0].name, "")
-}
-
-output "eventbridge_schedule_arns" {
-  description = "The EventBridge Schedule ARNs created"
-  value       = { for k in sort(keys(var.schedules)) : k => try(aws_scheduler_schedule.this[k].arn, null) if var.create && var.create_schedules }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,54 +5,75 @@ output "eventbridge_bus_name" {
 }
 
 output "eventbridge_bus_arn" {
-  description = "The EventBridge Bus Arn"
+  description = "The EventBridge Bus ARN"
   value       = try(aws_cloudwatch_event_bus.this[0].arn, "")
 }
 
 # EventBridge Archive
 output "eventbridge_archive_arns" {
-  description = "The EventBridge Archive Arns created"
+  description = "The EventBridge Archive ARNs"
   value       = { for v in aws_cloudwatch_event_archive.this : v.name => v.arn }
 }
 
 # EventBridge Permission
 output "eventbridge_permission_ids" {
-  description = "The EventBridge Permission Arns created"
+  description = "The EventBridge Permission IDs"
   value       = { for k, v in aws_cloudwatch_event_permission.this : k => v.id }
 }
 
 # EventBridge Connection
 output "eventbridge_connection_ids" {
-  description = "The EventBridge Connection IDs created"
+  description = "The EventBridge Connection IDs"
   value       = { for k, v in aws_cloudwatch_event_connection.this : k => v.id }
 }
 
 output "eventbridge_connection_arns" {
-  description = "The EventBridge Connection Arns created"
+  description = "The EventBridge Connection Arns"
   value       = { for k, v in aws_cloudwatch_event_connection.this : k => v.arn }
 }
 
 # EventBridge Destination
 output "eventbridge_api_destination_arns" {
-  description = "The EventBridge API Destination ARNs created"
+  description = "The EventBridge API Destination ARNs"
   value       = { for k, v in aws_cloudwatch_event_api_destination.this : k => v.arn }
 }
 
 # EventBridge Rule
 output "eventbridge_rule_ids" {
-  description = "The EventBridge Rule IDs created"
-  value       = { for k in sort(keys(var.rules)) : k => try(aws_cloudwatch_event_rule.this[k].id, null) if var.create && var.create_rules }
+  description = "The EventBridge Rule IDs"
+  value       = { for k, v in aws_cloudwatch_event_rule.this : k => v.id }
 }
 
 output "eventbridge_rule_arns" {
-  description = "The EventBridge Rule ARNs created"
-  value       = { for k in sort(keys(var.rules)) : k => try(aws_cloudwatch_event_rule.this[k].arn, null) if var.create && var.create_rules }
+  description = "The EventBridge Rule ARNs"
+  value       = { for k, v in aws_cloudwatch_event_rule.this : k => v.arn }
+}
+
+# EventBridge Schedule Groups
+output "eventbridge_schedule_group_ids" {
+  description = "The EventBridge Schedule Group IDs"
+  value       = { for k, v in aws_scheduler_schedule_group.this : k => v.id }
+}
+
+output "eventbridge_schedule_group_arns" {
+  description = "The EventBridge Schedule Group ARNs"
+  value       = { for k, v in aws_scheduler_schedule_group.this : k => v.arn }
+}
+
+output "eventbridge_schedule_group_states" {
+  description = "The EventBridge Schedule Group states"
+  value       = { for k, v in aws_scheduler_schedule_group.this : k => v.state }
 }
 
 # EventBridge Schedule
+output "eventbridge_schedule_ids" {
+  description = "The EventBridge Schedule IDs created"
+  value       = { for k, v in aws_scheduler_schedule.this : k => v.id }
+}
+
 output "eventbridge_schedule_arns" {
   description = "The EventBridge Schedule ARNs created"
-  value       = { for k in sort(keys(var.schedules)) : k => try(aws_scheduler_schedule.this[k].arn, null) if var.create && var.create_schedules }
+  value       = { for k, v in aws_scheduler_schedule.this : k => v.arn }
 }
 
 # IAM Role

--- a/outputs.tf
+++ b/outputs.tf
@@ -59,3 +59,8 @@ output "eventbridge_role_name" {
   description = "The name of the IAM role created for EventBridge"
   value       = try(aws_iam_role.eventbridge[0].name, "")
 }
+
+output "eventbridge_schedule_arns" {
+  description = "The EventBridge Schedule ARNs created"
+  value       = { for k in sort(keys(var.schedules)) : k => try(aws_scheduler_schedule.this[k].arn, null) if var.create && var.create_schedules }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -343,7 +343,7 @@ variable "attach_policy_statements" {
 }
 
 variable "trusted_entities" {
-  description = "Step Function additional trusted entities for assuming roles (trust relationship)"
+  description = "Additional trusted entities for assuming roles (trust relationship)"
   type        = list(string)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "append_destination_postfix" {
   default     = true
 }
 
+variable "append_schedule_group_postfix" {
+  description = "Controls whether to append '-group' to the name of the schedule group"
+  type        = bool
+  default     = true
+}
+
 variable "append_schedule_postfix" {
   description = "Controls whether to append '-schedule' to the name of the schedule"
   type        = bool
@@ -80,6 +86,12 @@ variable "create_schemas_discoverer" {
   description = "Controls whether default schemas discoverer should be created"
   type        = bool
   default     = false
+}
+
+variable "create_schedule_groups" {
+  description = "Controls whether EventBridge Schedule Group resources should be created"
+  type        = bool
+  default     = true
 }
 
 variable "create_schedules" {
@@ -144,6 +156,12 @@ variable "api_destinations" {
   default     = {}
 }
 
+variable "schedule_groups" {
+  description = "A map of objects with EventBridge Schedule Group definitions."
+  type        = any
+  default     = {}
+}
+
 variable "schedules" {
   description = "A map of objects with EventBridge Schedule definitions."
   type        = map(any)
@@ -152,6 +170,12 @@ variable "schedules" {
 
 variable "tags" {
   description = "A map of tags to assign to resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "schedule_group_timeouts" {
+  description = "A map of objects with EventBridge Schedule Group create and delete timeouts."
   type        = map(string)
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "append_destination_postfix" {
   default     = true
 }
 
+variable "append_schedule_postfix" {
+  description = "Controls whether to append '-schedule' to the name of the schedule"
+  type        = bool
+  default     = true
+}
+
 variable "create_bus" {
   description = "Controls whether EventBridge Bus resource should be created"
   type        = bool
@@ -74,6 +80,12 @@ variable "create_schemas_discoverer" {
   description = "Controls whether default schemas discoverer should be created"
   type        = bool
   default     = false
+}
+
+variable "create_schedules" {
+  description = "Controls whether EventBridge Schedule resources should be created"
+  type        = bool
+  default     = true
 }
 
 #######################
@@ -128,6 +140,12 @@ variable "connections" {
 
 variable "api_destinations" {
   description = "A map of objects with EventBridge Destination definitions."
+  type        = map(any)
+  default     = {}
+}
+
+variable "schedules" {
+  description = "A map of objects with EventBridge Schedule definitions."
   type        = map(any)
   default     = {}
 }


### PR DESCRIPTION
## Description
I have added basic support for the `aws_scheduler_schedule` resource type.

## Motivation and Context
Eventbridge support in the module would be more complete with this functionality. Indeed it may not be perfect or complete, but hopefully this is a starting point for full scheduler support in addition to the existing features supported by the module. This [issue](https://github.com/terraform-aws-modules/terraform-aws-eventbridge/issues/81) exists for discussion as well.

Fixes #81

## Breaking Changes
None.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
