### PR TITLE
feat: Add support for setting the condition field in Event Bus permissions

### DIFF
--- a/examples/with-permissions/README.md
+++ b/examples/with-permissions/README.md
@@ -42,6 +42,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|------|
 | [aws_cloudwatch_event_bus.external](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_bus) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_organizations_organization.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs
 

--- a/examples/with-permissions/main.tf
+++ b/examples/with-permissions/main.tf
@@ -9,6 +9,9 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
+data "aws_organizations_organization" "example" {}
+
+
 module "eventbridge" {
   source = "../../"
 
@@ -20,7 +23,8 @@ module "eventbridge" {
     "099720109477 DevAccess" = {}
 
     "099720109466 ProdAccess" = {
-      action = "events:PutEvents"
+      action        = "events:PutEvents"
+      condition_org = data.aws_organizations_organization.example.id
     }
 
     "* PublicAccessToExternalBus" = {

--- a/examples/with-permissions/main.tf
+++ b/examples/with-permissions/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "ap-southeast-1"
+  region = "us-east-1"
 
   # Make it faster by skipping something
   skip_get_ec2_platforms      = true
@@ -9,8 +9,7 @@ provider "aws" {
   skip_requesting_account_id  = true
 }
 
-data "aws_organizations_organization" "example" {}
-
+data "aws_organizations_organization" "this" {}
 
 module "eventbridge" {
   source = "../../"
@@ -23,18 +22,22 @@ module "eventbridge" {
     "099720109477 DevAccess" = {}
 
     "099720109466 ProdAccess" = {
-      action        = "events:PutEvents"
-      condition_org = data.aws_organizations_organization.example.id
+      action = "events:PutEvents"
     }
 
-    "* PublicAccessToExternalBus" = {
+    "* OrgAccessToExternalBus" = {
       event_bus_name = aws_cloudwatch_event_bus.external.name
+      condition_org  = data.aws_organizations_organization.this.id
     }
   }
 
   tags = {
     Name = "${random_pet.this.id}-bus"
   }
+
+  depends_on = [
+    random_pet.this
+  ]
 }
 
 ##################

--- a/examples/with-permissions/main.tf
+++ b/examples/with-permissions/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "us-east-1"
+  region = "ap-southeast-1"
 
   # Make it faster by skipping something
   skip_get_ec2_platforms      = true

--- a/examples/with-permissions/main.tf
+++ b/examples/with-permissions/main.tf
@@ -34,10 +34,6 @@ module "eventbridge" {
   tags = {
     Name = "${random_pet.this.id}-bus"
   }
-
-  depends_on = [
-    random_pet.this
-  ]
 }
 
 ##################

--- a/main.tf
+++ b/main.tf
@@ -218,9 +218,7 @@ resource "aws_cloudwatch_event_permission" "this" {
   event_bus_name = try(each.value["event_bus_name"], aws_cloudwatch_event_bus.this[0].name, var.bus_name, null)
 
   dynamic "condition" {
-    for_each = lookup(each.value, "condition_org", null) != null ? [
-      each.value.condition_org
-    ] : []
+    for_each = try([each.value.condition_org], [])
 
     content {
       key   = "aws:PrincipalOrgID"

--- a/main.tf
+++ b/main.tf
@@ -216,6 +216,18 @@ resource "aws_cloudwatch_event_permission" "this" {
 
   action         = lookup(each.value, "action", null)
   event_bus_name = try(each.value["event_bus_name"], aws_cloudwatch_event_bus.this[0].name, var.bus_name, null)
+
+  dynamic "condition" {
+    for_each = lookup(each.value, "condition_org", null) != null ? [
+      each.value.condition_org
+    ] : []
+
+    content {
+      key   = "aws:PrincipalOrgID"
+      type  = "StringEquals"
+      value = condition.value
+    }
+  }
 }
 
 resource "aws_cloudwatch_event_connection" "this" {


### PR DESCRIPTION
## Description
This PR adds a new `condition_org` field to the `permissions` maps that will be used to set the `condition` section of the `aws_cloudwatch_event_permission` resource to allow limiting access to an EventBridge bus.

## Motivation and Context
I wanted to be able to support more narrow permissions on an EventBridge bus akin to the examples shown in the terraform provider docs. Since complete map of `key`, `type` and `value` can't be passed in without making the entire variable an object, but `key` and `type` only have a single value, I opted to make the `value` the only field and set the remaining ones to their defaults when generating.

## Breaking Changes
This change is backwards compatible

## How Has This Been Tested?
I modified the examples/with-permission module to deploy an event bus with access limited to only a single organization and then used the cli to produce an event to the bus.

- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request