### PR TITLE
feat!: Bump Terraform version to 1.0 and updated `ecs_target` arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,13 +357,13 @@ module "eventbridge" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.64 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ module "eventbridge" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64 |
 
 ## Providers

--- a/examples/api-gateway-event-source/README.md
+++ b/examples/api-gateway-event-source/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 

--- a/examples/api-gateway-event-source/README.md
+++ b/examples/api-gateway-event-source/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.64 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/api-gateway-event-source/versions.tf
+++ b/examples/api-gateway-event-source/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/api-gateway-event-source/versions.tf
+++ b/examples/api-gateway-event-source/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7"
+      version = ">= 4.64"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
@@ -28,7 +28,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.64 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7"
+      version = ">= 4.64"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/default-bus/README.md
+++ b/examples/default-bus/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 

--- a/examples/default-bus/README.md
+++ b/examples/default-bus/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.64 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/default-bus/versions.tf
+++ b/examples/default-bus/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/default-bus/versions.tf
+++ b/examples/default-bus/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7"
+      version = ">= 4.64"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-api-destination/README.md
+++ b/examples/with-api-destination/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 

--- a/examples/with-api-destination/README.md
+++ b/examples/with-api-destination/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.64 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/with-api-destination/versions.tf
+++ b/examples/with-api-destination/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/with-api-destination/versions.tf
+++ b/examples/with-api-destination/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7"
+      version = ">= 4.64"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-archive/README.md
+++ b/examples/with-archive/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 

--- a/examples/with-archive/README.md
+++ b/examples/with-archive/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.64 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/with-archive/versions.tf
+++ b/examples/with-archive/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/with-archive/versions.tf
+++ b/examples/with-archive/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7"
+      version = ">= 4.64"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-ecs-scheduling/README.md
+++ b/examples/with-ecs-scheduling/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
@@ -34,8 +34,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | terraform-aws-modules/ecs/aws//modules/cluster | ~> 5.0 |
-| <a name="module_ecs_service"></a> [ecs\_service](#module\_ecs\_service) | terraform-aws-modules/ecs/aws//modules/service | ~> 5.0 |
+| <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | terraform-aws-modules/ecs/aws | ~> 5.0 |
 | <a name="module_eventbridge"></a> [eventbridge](#module\_eventbridge) | ../../ | n/a |
 
 ## Resources
@@ -44,7 +43,7 @@ Note that this example may create resources which cost money. Run `terraform des
 |------|------|
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
-| [aws_subnet_ids.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs

--- a/examples/with-ecs-scheduling/README.md
+++ b/examples/with-ecs-scheduling/README.md
@@ -34,15 +34,14 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecs"></a> [ecs](#module\_ecs) | terraform-aws-modules/ecs/aws | ~> 3.0 |
+| <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | terraform-aws-modules/ecs/aws//modules/cluster | ~> 5.0 |
+| <a name="module_ecs_service"></a> [ecs\_service](#module\_ecs\_service) | terraform-aws-modules/ecs/aws//modules/service | ~> 5.0 |
 | <a name="module_eventbridge"></a> [eventbridge](#module\_eventbridge) | ../../ | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_ecs_service.hello_world](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
-| [aws_ecs_task_definition.hello_world](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_subnet_ids.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |

--- a/examples/with-ecs-scheduling/README.md
+++ b/examples/with-ecs-scheduling/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.64 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/with-ecs-scheduling/main.tf
+++ b/examples/with-ecs-scheduling/main.tf
@@ -57,6 +57,8 @@ module "eventbridge" {
         attach_role_arn = true
 
         ecs_target = {
+          # If a capacity_provider_strategy specified, the launch_type parameter must be omitted.
+          # launch_type         = "FARGATE"
           task_count              = 1
           task_definition_arn     = aws_ecs_task_definition.hello_world.arn
           enable_ecs_managed_tags = true
@@ -71,6 +73,7 @@ module "eventbridge" {
           }
 
           # If a capacity_provider_strategy is specified, the launch_type parameter must be omitted.
+          # If no capacity_provider_strategy or launch_type is specified, the default capacity provider strategy for the cluster is used.
           capacity_provider_strategy = [
             {
               capacity_provider = "FARGATE"
@@ -79,7 +82,6 @@ module "eventbridge" {
             },
             {
               capacity_provider = "FARGATE_SPOT"
-              base              = 1
               weight            = 100
             }
           ]

--- a/examples/with-ecs-scheduling/main.tf
+++ b/examples/with-ecs-scheduling/main.tf
@@ -57,15 +57,38 @@ module "eventbridge" {
         attach_role_arn = true
 
         ecs_target = {
-          launch_type         = "FARGATE"
-          task_count          = 1
-          task_definition_arn = aws_ecs_task_definition.hello_world.arn
+          launch_type            = "FARGATE"
+          task_count             = 1
+          task_definition_arn    = aws_ecs_task_definition.hello_world.arn
+          enable_execute_command = true
+          tags                   = { production = true }
 
           network_configuration = {
             assign_public_ip = true
             subnets          = data.aws_subnet_ids.default.ids
             security_groups  = [data.aws_security_group.default.arn]
           }
+
+          capacity_provider_strategy = [{
+            capacity_provider = "test"
+            base              = 1
+            weight            = 100
+          }]
+
+          placement_constraint = [{
+            type = "distinctInstance"
+          }]
+
+          ordered_placement_strategy = [
+            {
+              type  = "spread"
+              field = "attribute:ecs.availability-zone"
+            },
+            {
+              type  = "spread"
+              field = "instanceId"
+            }
+          ]
         }
       }
     ]

--- a/examples/with-ecs-scheduling/main.tf
+++ b/examples/with-ecs-scheduling/main.tf
@@ -57,11 +57,12 @@ module "eventbridge" {
         attach_role_arn = true
 
         ecs_target = {
-          launch_type             = "FARGATE"
           task_count              = 1
           task_definition_arn     = aws_ecs_task_definition.hello_world.arn
           enable_ecs_managed_tags = true
-          tags                    = { production = true }
+          tags = {
+            production = true
+          }
 
           network_configuration = {
             assign_public_ip = true
@@ -69,11 +70,19 @@ module "eventbridge" {
             security_groups  = [data.aws_security_group.default.arn]
           }
 
-          capacity_provider_strategy = [{
-            capacity_provider = "test"
-            base              = 1
-            weight            = 100
-          }]
+          # If a capacity_provider_strategy is specified, the launch_type parameter must be omitted.
+          capacity_provider_strategy = [
+            {
+              capacity_provider = "FARGATE"
+              base              = 1
+              weight            = 100
+            },
+            {
+              capacity_provider = "FARGATE_SPOT"
+              base              = 1
+              weight            = 100
+            }
+          ]
 
           placement_constraint = [{
             type = "distinctInstance"

--- a/examples/with-ecs-scheduling/main.tf
+++ b/examples/with-ecs-scheduling/main.tf
@@ -57,11 +57,11 @@ module "eventbridge" {
         attach_role_arn = true
 
         ecs_target = {
-          launch_type            = "FARGATE"
-          task_count             = 1
-          task_definition_arn    = aws_ecs_task_definition.hello_world.arn
-          enable_execute_command = true
-          tags                   = { production = true }
+          launch_type             = "FARGATE"
+          task_count              = 1
+          task_definition_arn     = aws_ecs_task_definition.hello_world.arn
+          enable_ecs_managed_tags = true
+          tags                    = { production = true }
 
           network_configuration = {
             assign_public_ip = true

--- a/examples/with-ecs-scheduling/versions.tf
+++ b/examples/with-ecs-scheduling/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/with-ecs-scheduling/versions.tf
+++ b/examples/with-ecs-scheduling/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7"
+      version = ">= 4.64"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-lambda-scheduling/README.md
+++ b/examples/with-lambda-scheduling/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |

--- a/examples/with-lambda-scheduling/README.md
+++ b/examples/with-lambda-scheduling/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 

--- a/examples/with-lambda-scheduling/versions.tf
+++ b/examples/with-lambda-scheduling/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/with-lambda-scheduling/versions.tf
+++ b/examples/with-lambda-scheduling/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7"
+      version = ">= 4.64"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-permissions/README.md
+++ b/examples/with-permissions/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 

--- a/examples/with-permissions/README.md
+++ b/examples/with-permissions/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.64 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.64 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/with-permissions/versions.tf
+++ b/examples/with-permissions/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/examples/with-permissions/versions.tf
+++ b/examples/with-permissions/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7"
+      version = ">= 4.64"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -103,11 +103,15 @@ resource "aws_cloudwatch_event_target" "this" {
     ] : []
 
     content {
-      group               = lookup(ecs_target.value, "group", null)
-      launch_type         = lookup(ecs_target.value, "launch_type", null)
-      platform_version    = lookup(ecs_target.value, "platform_version", null)
-      task_count          = lookup(ecs_target.value, "task_count", null)
-      task_definition_arn = lookup(ecs_target.value, "task_definition_arn", null)
+      group                   = lookup(ecs_target.value, "group", null)
+      launch_type             = lookup(ecs_target.value, "launch_type", null)
+      platform_version        = lookup(ecs_target.value, "platform_version", null)
+      task_count              = lookup(ecs_target.value, "task_count", null)
+      task_definition_arn     = lookup(ecs_target.value, "task_definition_arn", null)
+      enable_ecs_managed_tags = lookup(ecs_target.value, "enable_ecs_managed_tags", null)
+      enable_execute_command  = lookup(ecs_target.value, "enable_execute_command", null)
+      propagate_tags          = lookup(ecs_target.value, "propagate_tags", null)
+      tags                    = lookup(ecs_target.value, "tags", null)
 
       dynamic "network_configuration" {
         for_each = lookup(ecs_target.value, "network_configuration", null) != null ? [
@@ -118,6 +122,34 @@ resource "aws_cloudwatch_event_target" "this" {
           subnets          = lookup(network_configuration.value, "subnets", null)
           security_groups  = lookup(network_configuration.value, "security_groups", null)
           assign_public_ip = lookup(network_configuration.value, "assign_public_ip", null)
+        }
+      }
+
+      dynamic "capacity_provider_strategy" {
+        for_each = try(ecs_target.value.capacity_provider_strategy, [])
+
+        content {
+          capacity_provider = try(capacity_provider_strategy.value.capacity_provider, null)
+          weight            = try(capacity_provider_strategy.value.weight, null)
+          base              = try(capacity_provider_strategy.value.base, null)
+        }
+      }
+
+      dynamic "ordered_placement_strategy" {
+        for_each = try(ecs_target.value.ordered_placement_strategy, [])
+
+        content {
+          type  = try(ordered_placement_strategy.value.type, null)
+          field = try(ordered_placement_strategy.value.field, null)
+        }
+      }
+
+      dynamic "placement_constraint" {
+        for_each = try(ecs_target.value.placement_constraint, [])
+
+        content {
+          type       = try(placement_constraint.value.type, null)
+          expression = try(placement_constraint.value.expression, null)
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -107,7 +107,7 @@ resource "aws_cloudwatch_event_target" "this" {
       launch_type             = lookup(ecs_target.value, "launch_type", null)
       platform_version        = lookup(ecs_target.value, "platform_version", null)
       task_count              = lookup(ecs_target.value, "task_count", null)
-      task_definition_arn     = lookup(ecs_target.value, "task_definition_arn", null)
+      task_definition_arn     = ecs_target.value.task_definition_arn
       enable_ecs_managed_tags = lookup(ecs_target.value, "enable_ecs_managed_tags", null)
       enable_execute_command  = lookup(ecs_target.value, "enable_execute_command", null)
       propagate_tags          = lookup(ecs_target.value, "propagate_tags", null)

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7"
+      version = ">= 4.64"
     }
   }
 }


### PR DESCRIPTION
## Description
Adding some additional `ecs_target` arguments. 

## Motivation and Context
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#ecs_target
https://github.com/hashicorp/terraform-provider-aws/pull/28384

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
