### PR TITLE
feat: Add attach_sns_policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.81.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ No modules.
 | [aws_iam_policy.kinesis_firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.sfn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.tracing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_attachment.additional_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
@@ -402,6 +403,7 @@ No modules.
 | [aws_iam_policy_attachment.kinesis_firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
 | [aws_iam_policy_attachment.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
 | [aws_iam_policy_attachment.sfn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_policy_attachment.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
 | [aws_iam_policy_attachment.sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
 | [aws_iam_policy_attachment.tracing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
 | [aws_iam_role.eventbridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -419,6 +421,7 @@ No modules.
 | [aws_iam_policy_document.kinesis_firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sfn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
@@ -442,6 +445,7 @@ No modules.
 | <a name="input_attach_policy_jsons"></a> [attach\_policy\_jsons](#input\_attach\_policy\_jsons) | Controls whether policy\_jsons should be added to IAM role | `bool` | `false` | no |
 | <a name="input_attach_policy_statements"></a> [attach\_policy\_statements](#input\_attach\_policy\_statements) | Controls whether policy\_statements should be added to IAM role | `bool` | `false` | no |
 | <a name="input_attach_sfn_policy"></a> [attach\_sfn\_policy](#input\_attach\_sfn\_policy) | Controls whether the StepFunction policy should be added to IAM role for EventBridge Target | `bool` | `false` | no |
+| <a name="input_attach_sns_policy"></a> [attach\_sns\_policy](#input\_attach\_sns\_policy) | Controls whether the SNS policy should be added to IAM role for EventBridge Target | `bool` | `false` | no |
 | <a name="input_attach_sqs_policy"></a> [attach\_sqs\_policy](#input\_attach\_sqs\_policy) | Controls whether the SQS policy should be added to IAM role for EventBridge Target | `bool` | `false` | no |
 | <a name="input_attach_tracing_policy"></a> [attach\_tracing\_policy](#input\_attach\_tracing\_policy) | Controls whether X-Ray tracing policy should be added to IAM role for EventBridge | `bool` | `false` | no |
 | <a name="input_bus_name"></a> [bus\_name](#input\_bus\_name) | A unique name for your EventBridge Bus | `string` | `"default"` | no |
@@ -479,6 +483,7 @@ No modules.
 | <a name="input_rules"></a> [rules](#input\_rules) | A map of objects with EventBridge Rule definitions. | `map(any)` | `{}` | no |
 | <a name="input_schemas_discoverer_description"></a> [schemas\_discoverer\_description](#input\_schemas\_discoverer\_description) | Default schemas discoverer description | `string` | `"Auto schemas discoverer event"` | no |
 | <a name="input_sfn_target_arns"></a> [sfn\_target\_arns](#input\_sfn\_target\_arns) | The Amazon Resource Name (ARN) of the StepFunctions you want to use as EventBridge targets | `list(string)` | `[]` | no |
+| <a name="input_sns_target_arns"></a> [sns\_target\_arns](#input\_sns\_target\_arns) | The Amazon Resource Name (ARN) of the AWS SNS's you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_sqs_target_arns"></a> [sqs\_target\_arns](#input\_sqs\_target\_arns) | The Amazon Resource Name (ARN) of the AWS SQS Queues you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |
 | <a name="input_targets"></a> [targets](#input\_targets) | A map of objects with EventBridge Target definitions. | `any` | `{}` | no |

--- a/examples/api-gateway-event-source/main.tf
+++ b/examples/api-gateway-event-source/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/default-bus/main.tf
+++ b/examples/default-bus/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-api-destination/main.tf
+++ b/examples/with-api-destination/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-archive/main.tf
+++ b/examples/with-archive/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-ecs-scheduling/main.tf
+++ b/examples/with-ecs-scheduling/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-lambda-scheduling/main.tf
+++ b/examples/with-lambda-scheduling/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/examples/with-permissions/main.tf
+++ b/examples/with-permissions/main.tf
@@ -2,7 +2,6 @@ provider "aws" {
   region = "ap-southeast-1"
 
   # Make it faster by skipping something
-  skip_get_ec2_platforms      = true
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true

--- a/iam.tf
+++ b/iam.tf
@@ -185,7 +185,7 @@ data "aws_iam_policy_document" "sns" {
   }
 
   statement {
-    sid    = "SNSAccess"
+    sid    = "SNSKMSAccess"
     effect = "Allow"
     actions = [
       "kms:Decrypt",

--- a/iam.tf
+++ b/iam.tf
@@ -180,11 +180,20 @@ data "aws_iam_policy_document" "sns" {
     effect = "Allow"
     actions = [
       "sns:Publish",
+    ]
+    resources = var.sns_target_arns
+  }
+
+  statement {
+    sid    = "SNSAccess"
+    effect = "Allow"
+    actions = [
       "kms:Decrypt",
       "kms:GenerateDataKey"
     ]
     resources = var.sns_target_arns
   }
+
 }
 
 resource "aws_iam_policy" "sns" {

--- a/iam.tf
+++ b/iam.tf
@@ -191,7 +191,7 @@ data "aws_iam_policy_document" "sns" {
       "kms:Decrypt",
       "kms:GenerateDataKey"
     ]
-    resources = var.sns_target_arns
+    resources = ["*"]
   }
 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -260,6 +260,12 @@ variable "sqs_target_arns" {
   default     = []
 }
 
+variable "sns_target_arns" {
+  description = "The Amazon Resource Name (ARN) of the AWS SNS's you want to use as EventBridge targets"
+  type        = list(string)
+  default     = []
+}
+
 variable "ecs_target_arns" {
   description = "The Amazon Resource Name (ARN) of the AWS ECS Tasks you want to use as EventBridge targets"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -200,6 +200,12 @@ variable "attach_sqs_policy" {
   default     = false
 }
 
+variable "attach_sns_policy" {
+  description = "Controls whether the SNS policy should be added to IAM role for EventBridge Target"
+  type        = bool
+  default     = false
+}
+
 variable "attach_ecs_policy" {
   description = "Controls whether the ECS policy should be added to IAM role for EventBridge Target"
   type        = bool


### PR DESCRIPTION
## Description

This pull request adds the `attach_sns_policy` flag to attach a permission policy to the sns target to allow the sending of event bridge notifications to sns. 

<!--- Describe your changes in detail -->

## Motivation and Context

Without assigning resource permissions to the sns target, event bridge rule fails to send the notification to sns.
https://repost.aws/knowledge-center/sns-not-getting-eventbridge-notification

Fixes https://github.com/terraform-aws-modules/terraform-aws-eventbridge/issues/88

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
