### PR TITLE
fix: Event bus data source count conditional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ locals {
 }
 
 data "aws_cloudwatch_event_bus" "this" {
-  count = (var.create && var.create_bus) || (var.bus_name == "") ? 0 : 1
+  count = var.create && var.create_bus ? 0 : 1
 
   name = var.bus_name
 }


### PR DESCRIPTION
## Description
In several examples (api-gateway-event-source, with-archive, with-api-destination), any example where `bus_name` is known after apply (generated randomly in this case), there is an invalid count argument error:
```
 Error: Invalid count argument
│ 
│   on ../../main.tf line 59, in data "aws_cloudwatch_event_bus" "this":
│   59:   count = (var.create && var.create_bus) || (var.bus_name == "") ? 0 : 1
│ 
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work
│ around this, use the -target argument to first apply only the resources that the count depends on.
╵
``` 
We can prevent this by removing the `|| (var.bus_name == "")` in the count conditional. 
`bus_name` defaults to `default` and I'm not seeing a use case where `bus_name` would be set to an empty string without producing errors for other reasons. 

## Motivation and Context
Remediate invalid count argument error. 

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
