### PR TITLE
feat: Add input_template in target_parameters for pipes

### DIFF
--- a/examples/with-pipes/main.tf
+++ b/examples/with-pipes/main.tf
@@ -134,6 +134,10 @@ module "eventbridge" {
         }
       }
 
+      target_parameters = {
+        input_template = "{\"data\":<$.dynamodb>}"
+      }
+
       tags = {
         Pipe = "dynamodb_stream_source_sqs_target"
       }

--- a/main.tf
+++ b/main.tf
@@ -697,6 +697,7 @@ resource "aws_pipes_pipe" "this" {
     for_each = try([each.value.target_parameters], [])
 
     content {
+      input_template = try(target_parameters.value.input_template, null)
       dynamic "sqs_queue_parameters" {
         for_each = try([target_parameters.value.sqs_queue_parameters], [])
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add `input_template` inside `target_parameters` for pipes. 
Add example for using it in `dynamodb_stream_source_sqs_target`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`input_template` can be specified for `target_parameters` to change the payload before sending it to the target.


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
