### PR TITLE
fix: Fixed newline handling in input_template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.4
+    rev: v1.86.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -569,6 +569,7 @@ No modules.
 | <a name="output_eventbridge_schedule_groups"></a> [eventbridge\_schedule\_groups](#output\_eventbridge\_schedule\_groups) | The EventBridge Schedule Groups created and their attributes |
 | <a name="output_eventbridge_schedule_ids"></a> [eventbridge\_schedule\_ids](#output\_eventbridge\_schedule\_ids) | The EventBridge Schedule IDs created |
 | <a name="output_eventbridge_schedules"></a> [eventbridge\_schedules](#output\_eventbridge\_schedules) | The EventBridge Schedules created and their attributes |
+| <a name="output_eventbridge_targets"></a> [eventbridge\_targets](#output\_eventbridge\_targets) | The EventBridge Targets created and their attributes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -86,4 +86,5 @@ No inputs.
 | <a name="output_eventbridge_rules"></a> [eventbridge\_rules](#output\_eventbridge\_rules) | The EventBridge Rules created and their attributes |
 | <a name="output_eventbridge_schedule_groups"></a> [eventbridge\_schedule\_groups](#output\_eventbridge\_schedule\_groups) | The EventBridge Schedule Groups created and their attributes |
 | <a name="output_eventbridge_schedules"></a> [eventbridge\_schedules](#output\_eventbridge\_schedules) | The EventBridge Schedules created and their attributes |
+| <a name="output_eventbridge_targets"></a> [eventbridge\_targets](#output\_eventbridge\_targets) | The EventBridge Targets created and their attributes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -221,7 +221,7 @@ locals {
     input_paths = {
       order_id = "$.detail.order_id"
     }
-    input_template = <<EOF
+    input_template = <<-EOF
     {
       "id": <order_id>
     }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -39,6 +39,11 @@ output "eventbridge_api_destinations" {
   value       = module.eventbridge.eventbridge_api_destinations
 }
 
+output "eventbridge_targets" {
+  description = "The EventBridge Targets created and their attributes"
+  value       = module.eventbridge.eventbridge_targets
+}
+
 output "eventbridge_rules" {
   description = "The EventBridge Rules created and their attributes"
   value       = module.eventbridge.eventbridge_rules

--- a/main.tf
+++ b/main.tf
@@ -228,7 +228,7 @@ resource "aws_cloudwatch_event_target" "this" {
 
     content {
       input_paths    = input_transformer.value.input_paths
-      input_template = input_transformer.value.input_template
+      input_template = chomp(input_transformer.value.input_template)
     }
   }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -135,6 +135,11 @@ output "eventbridge_api_destinations" {
   value       = aws_cloudwatch_event_api_destination.this
 }
 
+output "eventbridge_targets" {
+  description = "The EventBridge Targets created and their attributes"
+  value       = aws_cloudwatch_event_target.this
+}
+
 output "eventbridge_rules" {
   description = "The EventBridge Rules created and their attributes"
   value       = aws_cloudwatch_event_rule.this


### PR DESCRIPTION
## Description

Fixes https://github.com/terraform-aws-modules/terraform-aws-eventbridge/issues/106

It is important to use `<<-EOF` to get rid of spaces. `chomp()` will cut the last newline.
