### PR TITLE
fix: Allow API destinations to reuse connections

### DIFF
--- a/examples/with-api-destination/main.tf
+++ b/examples/with-api-destination/main.tf
@@ -164,9 +164,10 @@ module "eventbridge" {
       http_method                      = "POST"
       invocation_rate_limit_per_second = 20
     }
+    # reuse github connection
     refunds_github = {
       description                      = "my refunds to github endpoint"
-      invocation_endpoint              = "https://smee.io/hgoubGoIbWEKt331"
+      invocation_endpoint              = "https://smee.io/QaM356V2p1PFFZS"
       http_method                      = "POST"
       invocation_rate_limit_per_second = 20
       connection_name                  = "github"

--- a/examples/with-api-destination/main.tf
+++ b/examples/with-api-destination/main.tf
@@ -24,6 +24,11 @@ module "eventbridge" {
       event_pattern = jsonencode({ "source" : ["myapp.orders"] })
       state         = "ENABLED" # conflicts with enabled which is deprecated
     }
+    refunds = {
+      description   = "Capture all refund data"
+      event_pattern = jsonencode({ "source" : ["myapp.refunds"] })
+      state         = "ENABLED" # conflicts with enabled which is deprecated
+    }
   }
 
   targets = {
@@ -36,6 +41,13 @@ module "eventbridge" {
       {
         name            = "send-orders-to-github"
         destination     = "github"
+        attach_role_arn = true
+      }
+    ]
+    refunds = [
+      {
+        name            = "send-refunds-to-github"
+        destination     = "refunds_github"
         attach_role_arn = true
       }
     ]
@@ -151,6 +163,13 @@ module "eventbridge" {
       invocation_endpoint              = "https://smee.io/hgoubGoIbWEKt331"
       http_method                      = "POST"
       invocation_rate_limit_per_second = 20
+    }
+    refunds_github = {
+      description                      = "my refunds to github endpoint"
+      invocation_endpoint              = "https://smee.io/hgoubGoIbWEKt331"
+      http_method                      = "POST"
+      invocation_rate_limit_per_second = 20
+      connection_name                  = "github"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -425,7 +425,7 @@ resource "aws_cloudwatch_event_api_destination" "this" {
   invocation_endpoint              = each.value.invocation_endpoint
   http_method                      = each.value.http_method
   invocation_rate_limit_per_second = lookup(each.value, "invocation_rate_limit_per_second", null)
-  connection_arn                   = aws_cloudwatch_event_connection.this[each.value.name].arn
+  connection_arn                   = aws_cloudwatch_event_connection.this[try(each.value.connection_name, each.value.name)].arn
 }
 
 resource "aws_scheduler_schedule_group" "this" {

--- a/main.tf
+++ b/main.tf
@@ -425,7 +425,7 @@ resource "aws_cloudwatch_event_api_destination" "this" {
   invocation_endpoint              = each.value.invocation_endpoint
   http_method                      = each.value.http_method
   invocation_rate_limit_per_second = lookup(each.value, "invocation_rate_limit_per_second", null)
-  connection_arn                   = aws_cloudwatch_event_connection.this[try(each.value.connection_name, each.value.name)].arn
+  connection_arn                   = try(aws_cloudwatch_event_connection.this[each.value.connection_name].arn, aws_cloudwatch_event_connection.this[each.value.name].arn)
 }
 
 resource "aws_scheduler_schedule_group" "this" {


### PR DESCRIPTION
## Description
Allow API destinations to reuse the same connection. 
https://github.com/terraform-aws-modules/terraform-aws-eventbridge/issues/98

## Motivation and Context
Closes: https://github.com/terraform-aws-modules/terraform-aws-eventbridge/issues/98

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
