### PR TITLE
feat: Add support for multi targets

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -95,6 +95,32 @@ module "eventbridge" {
       {
         name = "log-orders-to-cloudwatch"
         arn  = aws_cloudwatch_log_group.this.arn
+      },
+      {
+        name  = "run-shell-script-one-target"
+        arn   = "arn:aws:ssm:${data.aws_region.current.name}::document/AWS-RunShellScript"
+        input = "{\"commands\": [\"uptime\"]}"
+        run_command_targets = [
+          {
+            key    = "InstanceIds"
+            values = ["i-123456"]
+          }
+        ]
+      },
+      {
+        name  = "run-shell-script-multi-target"
+        arn   = "arn:aws:ssm:${data.aws_region.current.name}::document/AWS-RunShellScript"
+        input = "{\"commands\": [\"uptime\"]}"
+        run_command_targets = [
+          {
+            key    = "tag:Name"
+            values = ["FooBar"]
+          },
+          {
+            key    = "InstanceIds"
+            values = ["i-123456"]
+          }
+        ]
       }
     ]
 

--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "aws_cloudwatch_event_target" "this" {
   input_path = lookup(each.value, "input_path", null)
 
   dynamic "run_command_targets" {
-    for_each = try([each.value.run_command_targets], [])
+    for_each = try(each.value.run_command_targets, [])
 
     content {
       key    = run_command_targets.value.key


### PR DESCRIPTION
## Description
Add support for multi target `run_command_targets`

## Motivation and Context
closes #113 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
Before this change: 
```tf
        run_command_targets = {
            key    = "InstanceIds"
            values = ["i-123456"]
          }
```
after this change:
```tf
        run_command_targets = [
          {
            key    = "tag:Name"
            values = ["FooBar"]
          },
          {
            key    = "InstanceIds"
            values = ["i-123456"]
          }
        ]


```

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

- [x] I have executed `pre-commit run -a` on my pull request
