### PR TITLE
fix: Made input_paths in input_transformer optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -227,7 +227,7 @@ resource "aws_cloudwatch_event_target" "this" {
     ] : []
 
     content {
-      input_paths    = input_transformer.value.input_paths
+      input_paths    = try(input_transformer.value.input_paths, null)
       input_template = chomp(input_transformer.value.input_template)
     }
   }


### PR DESCRIPTION
Per AWS provider documentation,`input_paths` is not required.

Fixes #117 

## Description
Per the AWS Provider documentation on [aws_cloudwatch_event_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#input_transformer), `input_paths` is optional.

## Motivation and Context
Scenario:
You have a rule of type "Scehduled Standard" and a target of a Batch job queue. You wish to use an `input_transformer` of type "Constant" and supply some static JSON for `input_template`. This means you will not have any need for `input_paths`. Currently the module _requires_ `input_paths` to be set.

## Breaking Changes
Not that I am aware

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
I use this module at my place of employment and have tested this change with our implementation of this module and confirmed the change requested here does not break usage of the module.
- [x] I have executed `pre-commit run -a` on my pull request
