### PR TITLE
fix: Fix kinesis_target and kinesis_parameters dynamic blocks

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -105,11 +105,12 @@ module "eventbridge" {
         attach_role_arn = true
       },
       {
-        name              = "send-orders-to-kinesis"
-        arn               = aws_kinesis_stream.this.arn
-        dead_letter_arn   = aws_sqs_queue.dlq.arn
-        input_transformer = local.order_input_transformer
-        attach_role_arn   = true
+        name               = "send-orders-to-kinesis"
+        arn                = aws_kinesis_stream.this.arn
+        dead_letter_arn    = aws_sqs_queue.dlq.arn
+        input_transformer  = local.order_input_transformer
+        partition_key_path = "$.id"
+        attach_role_arn    = true
       },
       {
         name            = "process-email-with-ecs-task",

--- a/examples/with-schedules/README.md
+++ b/examples/with-schedules/README.md
@@ -28,6 +28,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.27 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
@@ -42,6 +43,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
+| [aws_kinesis_stream.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_stream) | resource |
 | [null_resource.download_package](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 

--- a/examples/with-schedules/main.tf
+++ b/examples/with-schedules/main.tf
@@ -42,6 +42,12 @@ module "eventbridge" {
       schedule_expression = "rate(10 hours)"
       arn                 = module.lambda.lambda_function_arn
     }
+    kinesis-cron = {
+      group_name          = "prod"
+      schedule_expression = "rate(10 hours)"
+      arn                 = aws_kinesis_stream.this.arn
+      partition_key       = "foo"
+    }
   }
 }
 
@@ -51,6 +57,11 @@ module "eventbridge" {
 
 resource "random_pet" "this" {
   length = 2
+}
+
+resource "aws_kinesis_stream" "this" {
+  name        = random_pet.this.id
+  shard_count = 1
 }
 
 #############################################

--- a/main.tf
+++ b/main.tf
@@ -194,10 +194,10 @@ resource "aws_cloudwatch_event_target" "this" {
   }
 
   dynamic "kinesis_target" {
-    for_each = lookup(each.value, "kinesis_target", null) != null ? [true] : []
+    for_each = lookup(each.value, "partition_key_path", null) != null ? [true] : []
 
     content {
-      partition_key_path = lookup(kinesis_target.value, "partition_key_path", null)
+      partition_key_path = each.value.partition_key_path
     }
   }
 
@@ -560,10 +560,10 @@ resource "aws_scheduler_schedule" "this" {
     }
 
     dynamic "kinesis_parameters" {
-      for_each = lookup(each.value, "kinesis_parameters", null) != null ? [true] : []
+      for_each = lookup(each.value, "partition_key", null) != null ? [true] : []
 
       content {
-        partition_key = kinesis_parameters.value.partition_key
+        partition_key = each.value.partition_key
       }
     }
 


### PR DESCRIPTION
## Description
Reopened #91 as the issue is still present.

## Motivation and Context
### Target
Before this change the target configuration for kinesis partition seems to be intended to look like this:
```terraform
kinesis_target = {
  partition_key_path = “$.id”
}
```
Actually planning with this configuration present will error out though. Reason for this is that the for_each will assign the iterator to just `[true]` and subsequently try to access a field on it:
```
│ Error: Invalid function argument
│ 
│   on ../../main.tf line 200, in resource "aws_cloudwatch_event_target" "this":
│  200:       partition_key_path = lookup(kinesis_target.value, "partition_key_path", null)
│     ├────────────────
│     │ kinesis_target.value is true
│ 
│ Invalid value for "inputMap" parameter: lookup() requires a map as the first argument.
```
After this change the configuration looks like this and works as intended (see examples):
```terraform
partition_key_path = "$.id"
```
### Schedule

Before this change the target configuration for kinesis partition key seems to be intended to look like this:
```terraform
kinesis_parameters = {
  partition_key = “foo”
}
```
Actually planning with this configuration present will error out though.
Reason for this is the the schedule input would no longer be a valid map due to inconsistent types:
```
│ The given value is not suitable for module.eventbridge.var.schedules declared at ../../variables.tf:177,1-21: attribute types must all match for conversion
│ to map.
```
Additionally even if it passed the for_each will assign the iterator to just `[true]` and subsequently try to access a field on it --- failing either way.

After this change the configuration looks like this and works as intended (see examples):
```terraform
partition_key  = "foo"
```

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No, as the functionality was not working in the first place.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
