### PR TITLE
feat: move from deprecated attribute

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_cloudwatch_event_rule" "this" {
   event_bus_name = var.create_bus ? aws_cloudwatch_event_bus.this[0].name : var.bus_name
 
   description         = lookup(each.value, "description", null)
-  is_enabled          = lookup(each.value, "enabled", null)
+  state               = lookup(each.value, "enabled", null)
   event_pattern       = lookup(each.value, "event_pattern", null)
   schedule_expression = lookup(each.value, "schedule_expression", null)
   role_arn            = lookup(each.value, "role_arn", false) ? aws_iam_role.eventbridge[0].arn : null


### PR DESCRIPTION
This PR is to update the deprecated parameter in aws_cloudwatch_event_rule TF resource

## Description
Warning: Argument is deprecated
with module.my-module.module.eventbridge.aws_cloudwatch_event_rule.this["test"]
on .terraform/modules/my-module.eventbridge/main.tf line 91, in resource "aws_cloudwatch_event_rule" "this":
  is_enabled          = lookup(each.value, "enabled", null)
Use "state" instead

## Motivation and Context
We need to follow the latest syntax for AWS provider and available resources according to the official documentation.

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
