### PR TITLE
fix: Default to null when state argument is not set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "aws_cloudwatch_event_rule" "this" {
   event_pattern       = lookup(each.value, "event_pattern", null)
   schedule_expression = lookup(each.value, "schedule_expression", null)
   role_arn            = lookup(each.value, "role_arn", false) ? aws_iam_role.eventbridge[0].arn : null
-  state               = try(each.value.enabled ? "ENABLED" : "DISABLED", tobool(each.value.state) ? "ENABLED" : "DISABLED", upper(each.value.state), "DISABLED")
+  state               = try(each.value.enabled ? "ENABLED" : "DISABLED", tobool(each.value.state) ? "ENABLED" : "DISABLED", upper(each.value.state), null)
 
   tags = merge(var.tags, {
     Name = each.value.Name


### PR DESCRIPTION
## Description
Changes the default value of `aws_cloudwatch_event_rule` to be `ENABLED` if neither the attributes `enabled` or `state` is set.

## Motivation and Context
Fixes the issue introduces in v.3.3.0 https://github.com/terraform-aws-modules/terraform-aws-eventbridge/issues/121 where missing attributes defaults to the opposite value of the vanilla Terraform resource.

## Breaking Changes
The change reestablished compatibility with Terraform defaults.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
