### PR TITLE
feat: Make eventbridge connections output sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -128,6 +128,7 @@ output "eventbridge_permissions" {
 output "eventbridge_connections" {
   description = "The EventBridge Connections created and their attributes"
   value       = aws_cloudwatch_event_connection.this
+  sensitive   = true
 }
 
 output "eventbridge_api_destinations" {


### PR DESCRIPTION
Atm with the aws provider this module fails as the event bridge connection output is sensitve but not declared as sensitive in the module

The output fails 
╷
│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 128:
│  128: output "eventbridge_connections" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true