### PR TITLE
feat: Added path parameter for aws_iam_policy resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ No modules.
 | <a name="input_policy"></a> [policy](#input\_policy) | An additional policy document ARN to attach to IAM role | `string` | `null` | no |
 | <a name="input_policy_json"></a> [policy\_json](#input\_policy\_json) | An additional policy document as JSON to attach to IAM role | `string` | `null` | no |
 | <a name="input_policy_jsons"></a> [policy\_jsons](#input\_policy\_jsons) | List of additional policy documents as JSON to attach to IAM role | `list(string)` | `[]` | no |
+| <a name="input_policy_path"></a> [policy\_path](#input\_policy\_path) | Path of IAM policy to use for EventBridge | `string` | `null` | no |
 | <a name="input_policy_statements"></a> [policy\_statements](#input\_policy\_statements) | Map of dynamic policy statements to attach to IAM role | `any` | `{}` | no |
 | <a name="input_role_description"></a> [role\_description](#input\_role\_description) | Description of IAM role to use for EventBridge | `string` | `null` | no |
 | <a name="input_role_force_detach_policies"></a> [role\_force\_detach\_policies](#input\_role\_force\_detach\_policies) | Specifies to force detaching any policies the IAM role has before destroying it. | `bool` | `true` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -58,6 +58,7 @@ resource "aws_iam_policy" "tracing" {
 
   name   = "${local.role_name}-tracing"
   policy = data.aws_iam_policy.tracing[0].policy
+  path   = var.policy_path
 
   tags = merge({ Name = "${local.role_name}-tracing" }, var.tags)
 }
@@ -90,6 +91,7 @@ resource "aws_iam_policy" "kinesis" {
 
   name   = "${local.role_name}-kinesis"
   policy = data.aws_iam_policy_document.kinesis[0].json
+  path   = var.policy_path
 
   tags = merge({ Name = "${local.role_name}-kinesis" }, var.tags)
 }
@@ -122,6 +124,7 @@ resource "aws_iam_policy" "kinesis_firehose" {
 
   name   = "${local.role_name}-kinesis-firehose"
   policy = data.aws_iam_policy_document.kinesis_firehose[0].json
+  path   = var.policy_path
 
   tags = merge({ Name = "${local.role_name}-kinesis-firehose" }, var.tags)
 }
@@ -158,6 +161,7 @@ resource "aws_iam_policy" "sqs" {
 
   name   = "${local.role_name}-sqs"
   policy = data.aws_iam_policy_document.sqs[0].json
+  path   = var.policy_path
 
   tags = merge({ Name = "${local.role_name}-sqs" }, var.tags)
 }
@@ -203,6 +207,7 @@ resource "aws_iam_policy" "sns" {
 
   name   = "${local.role_name}-sns"
   policy = data.aws_iam_policy_document.sns[0].json
+  path   = var.policy_path
 
   tags = merge({ Name = "${local.role_name}-sns" }, var.tags)
 }
@@ -242,6 +247,7 @@ resource "aws_iam_policy" "ecs" {
 
   name   = "${local.role_name}-ecs"
   policy = data.aws_iam_policy_document.ecs[0].json
+  path   = var.policy_path
 
   tags = merge({ Name = "${local.role_name}-ecs" }, var.tags)
 }
@@ -274,6 +280,7 @@ resource "aws_iam_policy" "lambda" {
 
   name   = "${local.role_name}-lambda"
   policy = data.aws_iam_policy_document.lambda[0].json
+  path   = var.policy_path
 
   tags = merge({ Name = "${local.role_name}-lambda" }, var.tags)
 }
@@ -306,6 +313,7 @@ resource "aws_iam_policy" "sfn" {
 
   name   = "${local.role_name}-sfn"
   policy = data.aws_iam_policy_document.sfn[0].json
+  path   = var.policy_path
 
   tags = merge({ Name = "${local.role_name}-sfn" }, var.tags)
 }
@@ -338,6 +346,7 @@ resource "aws_iam_policy" "api_destination" {
 
   name   = "${local.role_name}-api-destination"
   policy = data.aws_iam_policy_document.api_destination[0].json
+  path   = var.policy_path
 
   tags = merge({ Name = "${local.role_name}-api-destination" }, var.tags)
 }
@@ -374,6 +383,7 @@ resource "aws_iam_policy" "cloudwatch" {
 
   name   = "${local.role_name}-cloudwatch"
   policy = data.aws_iam_policy_document.cloudwatch[0].json
+  path   = var.policy_path
 
   tags = merge({ Name = "${local.role_name}-cloudwatch" }, var.tags)
 }
@@ -417,6 +427,7 @@ resource "aws_iam_policy" "additional_jsons" {
 
   name   = "${local.role_name}-${count.index}"
   policy = var.policy_jsons[count.index]
+  path   = var.policy_path
 
   tags = merge({ Name = "${local.role_name}-${count.index}" }, var.tags)
 }
@@ -502,6 +513,7 @@ resource "aws_iam_policy" "additional_inline" {
 
   name   = "${local.role_name}-inline"
   policy = data.aws_iam_policy_document.additional_inline[0].json
+  path   = var.policy_path
 
   tags = merge({ Name = "${local.role_name}-inline" }, var.tags)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -220,6 +220,12 @@ variable "role_path" {
   default     = null
 }
 
+variable "policy_path" {
+  description = "Path of IAM policy to use for EventBridge"
+  type        = string
+  default     = null
+}
+
 variable "role_force_detach_policies" {
   description = "Specifies to force detaching any policies the IAM role has before destroying it."
   type        = bool


### PR DESCRIPTION
## Description
This PR addds the `policy_path` variable, to allow for the use of paths within the created iam policies.

## Motivation and Context
The IAM Role currently supports paths but the policies are not, to be able to work nicely with permission boundaries and/or SCPs, it's preferable to have a path on the policies as well.

Fixes https://github.com/terraform-aws-modules/terraform-aws-eventbridge/issues/126

## Breaking Changes
Should not have breaking changes, the default value is null, as is the default value of the provider.

## How Has This Been Tested?

Can test after working hours.

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
