### PR TITLE
feat: Added sns_kms_arns parameter for granular kms access inside sns aws_iam_policy resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ No modules.
 | <a name="input_schedules"></a> [schedules](#input\_schedules) | A map of objects with EventBridge Schedule definitions. | `map(any)` | `{}` | no |
 | <a name="input_schemas_discoverer_description"></a> [schemas\_discoverer\_description](#input\_schemas\_discoverer\_description) | Default schemas discoverer description | `string` | `"Auto schemas discoverer event"` | no |
 | <a name="input_sfn_target_arns"></a> [sfn\_target\_arns](#input\_sfn\_target\_arns) | The Amazon Resource Name (ARN) of the StepFunctions you want to use as EventBridge targets | `list(string)` | `[]` | no |
+| <a name="input_sns_kms_arns"></a> [sns\_kms\_arns](#input\_sns\_kms\_arns) | The Amazon Resource Name (ARN) of the AWS KMS's configured for AWS SNS you want Decrypt/GenerateDataKey for | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_sns_target_arns"></a> [sns\_target\_arns](#input\_sns\_target\_arns) | The Amazon Resource Name (ARN) of the AWS SNS's you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_sqs_target_arns"></a> [sqs\_target\_arns](#input\_sqs\_target\_arns) | The Amazon Resource Name (ARN) of the AWS SQS Queues you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -190,14 +190,18 @@ data "aws_iam_policy_document" "sns" {
     resources = var.sns_target_arns
   }
 
-  statement {
-    sid    = "SNSKMSAccess"
-    effect = "Allow"
-    actions = [
-      "kms:Decrypt",
-      "kms:GenerateDataKey"
-    ]
-    resources = ["*"]
+  dynamic "statement" {
+    for_each = length(var.sns_kms_arns) > 0 ? [1] : []
+
+    content {
+      sid    = "SNSKMSAccess"
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = var.sns_kms_arns
+    }
   }
 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -332,6 +332,12 @@ variable "sns_target_arns" {
   default     = []
 }
 
+variable "sns_kms_arns" {
+  description = "The Amazon Resource Name (ARN) of the AWS KMS's configured for AWS SNS you want Decrypt/GenerateDataKey for"
+  type        = list(string)
+  default     = ["*"]
+}
+
 variable "ecs_target_arns" {
   description = "The Amazon Resource Name (ARN) of the AWS ECS Tasks you want to use as EventBridge targets"
   type        = list(string)


### PR DESCRIPTION
## Description
This PR adds backwards compatible logic which gives the user the possibility to configure specific KMS arns, or even zero arns to to the policy related to SNS.

## Motivation and Context
Currently a wildcard is used inside the iam policy which is something SecurityHub is complaining about.

## Breaking Changes
It is backwards compatible as it uses the list ["*"] as default.

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
