### PR TITLE
feat: Updating default ECS policies to allow for Tagging

### DIFF
--- a/examples/with-schedules/README.md
+++ b/examples/with-schedules/README.md
@@ -28,7 +28,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.27 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.53 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 

--- a/iam.tf
+++ b/iam.tf
@@ -232,9 +232,12 @@ data "aws_iam_policy_document" "ecs" {
   count = local.create_role && var.attach_ecs_policy ? 1 : 0
 
   statement {
-    sid       = "ECSAccess"
-    effect    = "Allow"
-    actions   = ["ecs:RunTask"]
+    sid    = "ECSAccess"
+    effect = "Allow"
+    actions = [
+      "ecs:RunTask",
+      "ecs:TagResource"
+    ]
     resources = [for arn in var.ecs_target_arns : replace(arn, "/:\\d+$/", ":*")]
   }
 

--- a/iam_pipes.tf
+++ b/iam_pipes.tf
@@ -260,7 +260,8 @@ locals {
 
     ecs = {
       actions = [
-        "ecs:RunTask"
+        "ecs:RunTask",
+        "ecs:TagResource"
       ]
     }
 


### PR DESCRIPTION
## Description
Add `ecs:TagResource` to default ECS permissions

## Motivation and Context
AWS is making a change to the `ecs:RunTask` API to allow customers to specify if tags can be set or not
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#tag-resources-timeline

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
