### PR TITLE
feat: Allow specifying ecs policy passrole resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,7 +509,7 @@ No modules.
 | <a name="input_lambda_target_arns"></a> [lambda\_target\_arns](#input\_lambda\_target\_arns) | The Amazon Resource Name (ARN) of the Lambda Functions you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_number_of_policies"></a> [number\_of\_policies](#input\_number\_of\_policies) | Number of policies to attach to IAM role | `number` | `0` | no |
 | <a name="input_number_of_policy_jsons"></a> [number\_of\_policy\_jsons](#input\_number\_of\_policy\_jsons) | Number of policies JSON to attach to IAM role | `number` | `0` | no |
-| <a name="input_pass_role_resources"></a> [pass\_role\_resources](#input\_pass\_role\_resources) | List of approved roles to be passed | `list(string)` | `null` | no |
+| <a name="input_pass_role_resources"></a> [pass\_role\_resources](#input\_pass\_role\_resources) | List of approved roles to be passed | `list(string)` | `[]` | no |
 | <a name="input_permissions"></a> [permissions](#input\_permissions) | A map of objects with EventBridge Permission definitions. | `map(any)` | `{}` | no |
 | <a name="input_pipes"></a> [pipes](#input\_pipes) | A map of objects with EventBridge Pipe definitions. | `any` | `{}` | no |
 | <a name="input_policies"></a> [policies](#input\_policies) | List of policy statements ARN to attach to IAM role | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ No modules.
 | <a name="input_create_schedules"></a> [create\_schedules](#input\_create\_schedules) | Controls whether EventBridge Schedule resources should be created | `bool` | `true` | no |
 | <a name="input_create_schemas_discoverer"></a> [create\_schemas\_discoverer](#input\_create\_schemas\_discoverer) | Controls whether default schemas discoverer should be created | `bool` | `false` | no |
 | <a name="input_create_targets"></a> [create\_targets](#input\_create\_targets) | Controls whether EventBridge Target resources should be created | `bool` | `true` | no |
+| <a name="input_ecs_pass_role_resources"></a> [ecs\_pass\_role\_resources](#input\_ecs\_pass\_role\_resources) | List of approved roles to be passed | `list(string)` | `[]` | no |
 | <a name="input_ecs_target_arns"></a> [ecs\_target\_arns](#input\_ecs\_target\_arns) | The Amazon Resource Name (ARN) of the AWS ECS Tasks you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_event_source_name"></a> [event\_source\_name](#input\_event\_source\_name) | The partner event source that the new event bus will be matched with. Must match name. | `string` | `null` | no |
 | <a name="input_kinesis_firehose_target_arns"></a> [kinesis\_firehose\_target\_arns](#input\_kinesis\_firehose\_target\_arns) | The Amazon Resource Name (ARN) of the Kinesis Firehose Delivery Streams you want to use as EventBridge targets | `list(string)` | `[]` | no |
@@ -509,7 +510,6 @@ No modules.
 | <a name="input_lambda_target_arns"></a> [lambda\_target\_arns](#input\_lambda\_target\_arns) | The Amazon Resource Name (ARN) of the Lambda Functions you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_number_of_policies"></a> [number\_of\_policies](#input\_number\_of\_policies) | Number of policies to attach to IAM role | `number` | `0` | no |
 | <a name="input_number_of_policy_jsons"></a> [number\_of\_policy\_jsons](#input\_number\_of\_policy\_jsons) | Number of policies JSON to attach to IAM role | `number` | `0` | no |
-| <a name="input_pass_role_resources"></a> [pass\_role\_resources](#input\_pass\_role\_resources) | List of approved roles to be passed | `list(string)` | `[]` | no |
 | <a name="input_permissions"></a> [permissions](#input\_permissions) | A map of objects with EventBridge Permission definitions. | `map(any)` | `{}` | no |
 | <a name="input_pipes"></a> [pipes](#input\_pipes) | A map of objects with EventBridge Pipe definitions. | `any` | `{}` | no |
 | <a name="input_policies"></a> [policies](#input\_policies) | List of policy statements ARN to attach to IAM role | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ No modules.
 | <a name="input_lambda_target_arns"></a> [lambda\_target\_arns](#input\_lambda\_target\_arns) | The Amazon Resource Name (ARN) of the Lambda Functions you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_number_of_policies"></a> [number\_of\_policies](#input\_number\_of\_policies) | Number of policies to attach to IAM role | `number` | `0` | no |
 | <a name="input_number_of_policy_jsons"></a> [number\_of\_policy\_jsons](#input\_number\_of\_policy\_jsons) | Number of policies JSON to attach to IAM role | `number` | `0` | no |
+| <a name="input_pass_role_resources"></a> [pass\_role\_resources](#input\_pass\_role\_resources) | List of approved roles to be passed | `list(string)` | `null` | no |
 | <a name="input_permissions"></a> [permissions](#input\_permissions) | A map of objects with EventBridge Permission definitions. | `map(any)` | `{}` | no |
 | <a name="input_pipes"></a> [pipes](#input\_pipes) | A map of objects with EventBridge Pipe definitions. | `any` | `{}` | no |
 | <a name="input_policies"></a> [policies](#input\_policies) | List of policy statements ARN to attach to IAM role | `list(string)` | `[]` | no |

--- a/examples/with-ecs-scheduling/README.md
+++ b/examples/with-ecs-scheduling/README.md
@@ -42,6 +42,8 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Type |
 |------|------|
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_subnets.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |

--- a/examples/with-ecs-scheduling/main.tf
+++ b/examples/with-ecs-scheduling/main.tf
@@ -46,7 +46,7 @@ module "eventbridge" {
     "arn:aws:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:task/${random_pet.this.id}/*"
   ]
 
-  pass_role_resources = [module.ecs_cluster.services["hello-world"].task_exec_iam_role_arn]
+  ecs_pass_role_resources = [module.ecs_cluster.services["hello-world"].task_exec_iam_role_arn]
 
   # Fire every five minutes
   rules = {

--- a/examples/with-ecs-scheduling/main.tf
+++ b/examples/with-ecs-scheduling/main.tf
@@ -26,6 +26,9 @@ data "aws_subnets" "default" {
   }
 }
 
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
 ####################
 # Actual Eventbridge
 ####################
@@ -38,7 +41,12 @@ module "eventbridge" {
   create_role       = true
   role_name         = "ecs-eventbridge-${random_pet.this.id}"
   attach_ecs_policy = true
-  ecs_target_arns   = [module.ecs_cluster.services["hello-world"].task_definition_arn]
+  ecs_target_arns = [
+    module.ecs_cluster.services["hello-world"].task_definition_arn,
+    "arn:aws:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:task/${random_pet.this.id}/*"
+  ]
+
+  pass_role_resources = [module.ecs_cluster.services["hello-world"].task_exec_iam_role_arn]
 
   # Fire every five minutes
   rules = {

--- a/iam.tf
+++ b/iam.tf
@@ -245,7 +245,7 @@ data "aws_iam_policy_document" "ecs" {
     sid       = "PassRole"
     effect    = "Allow"
     actions   = ["iam:PassRole"]
-    resources = coalescelist(var.pass_role_resources, ["*"])
+    resources = coalescelist(var.ecs_pass_role_resources, ["*"])
   }
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -245,7 +245,7 @@ data "aws_iam_policy_document" "ecs" {
     sid       = "PassRole"
     effect    = "Allow"
     actions   = ["iam:PassRole"]
-    resources = ["*"]
+    resources = coalesce(var.pass_role_resources, ["*"])
   }
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -245,7 +245,7 @@ data "aws_iam_policy_document" "ecs" {
     sid       = "PassRole"
     effect    = "Allow"
     actions   = ["iam:PassRole"]
-    resources = coalesce(var.pass_role_resources, ["*"])
+    resources = coalescelist(var.pass_role_resources, ["*"])
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -244,6 +244,12 @@ variable "role_tags" {
   default     = {}
 }
 
+variable "pass_role_resources" {
+  description = "List of approved roles to be passed"
+  type        = list(string)
+  default     = null
+}
+
 ###########
 # Policies
 ###########

--- a/variables.tf
+++ b/variables.tf
@@ -244,7 +244,7 @@ variable "role_tags" {
   default     = {}
 }
 
-variable "pass_role_resources" {
+variable "ecs_pass_role_resources" {
   description = "List of approved roles to be passed"
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -247,7 +247,7 @@ variable "role_tags" {
 variable "pass_role_resources" {
   description = "List of approved roles to be passed"
   type        = list(string)
-  default     = null
+  default     = []
 }
 
 ###########


### PR DESCRIPTION
## Description
Allow specifying what roles can be passed using the PassRole action. 

## Motivation and Context
Closes: https://github.com/terraform-aws-modules/terraform-aws-eventbridge/issues/128

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
