### PR TITLE
fix: Add `depends_on` policy and policy attachments for pipes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -810,4 +810,9 @@ resource "aws_pipes_pipe" "this" {
   }
 
   tags = merge(var.tags, try(each.value.tags, {}))
+
+  depends_on = [
+    aws_iam_policy.service,
+    aws_iam_policy_attachment.service
+  ]
 }


### PR DESCRIPTION
## Description
Pipes requires permissions for source and target actions to be attached prior to creation otherwise the following error occurs (example of one from examples/with-pipes):
```
╷
│ Error: waiting for creation AWS EventBridge Pipes Pipe (sqs-source-lambda-target-pipe): unexpected state 'CREATE_FAILED', wanted target 'RUNNING, STOPPED'. last error: Input parameter is invalid from the request due to : The provided customer role does not have permissions to call ReceiveMessage on SQS
│ 
│   with module.eventbridge.aws_pipes_pipe.this["sqs_source_lambda_target"],
│   on ../../main.tf line 611, in resource "aws_pipes_pipe" "this":
│  611: resource "aws_pipes_pipe" "this" {
│ 
╵
```

## Motivation and Context
Permissions are required to be attached to the pipes role prior to creation otherwise error occurs. 

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
