### PR TITLE
feat: Update IAM pipes to support step function sync executions

### DIFF
--- a/iam_pipes.tf
+++ b/iam_pipes.tf
@@ -227,7 +227,8 @@ locals {
 
     step_functions = {
       actions = [
-        "states:StartExecution"
+        "states:StartExecution",
+        "states:StartSyncExecution"
       ]
     }
 


### PR DESCRIPTION
## Description
It looks like we're missing the states:StartSyncExecution action so we can execute step functions using the REQUEST_RESPONSE invocation_type

## Motivation and Context
I was trying to use EB Pipes executing a step function using the REQUEST_RESPONSE invocation_type but getting the IAM error
```
{
    "resourceArn": "arn:aws:pipes:eu-central-1:*:pipe/*-pipe",
    "timestamp": 1726151215307,
    "executionId": "*",
    "messageType": "ExecutionFailed",
    "logLevel": "ERROR",
    "error": {
        "message": "Target invocation failed with error from States. Not allowed to invoke arn:aws:states:eu-central-1:*:stateMachine:*.",
        "httpStatusCode": 400,
        "awsService": "states",
        "requestId": "*",
        "exceptionType": "AccessDenied",
        "resourceArn": "arn:aws:states:eu-central-1:*:stateMachine:*"
    }
}

```
and discovered it's not included

## Breaking Changes
No
