### PR TITLE
fix: Cloudwatch policy for pipes

### DIFF
--- a/iam_pipes.tf
+++ b/iam_pipes.tf
@@ -60,7 +60,16 @@ locals {
           matching_services = ["batch"]
         },
         logs = {
-          values            = [v.target],
+          values = flatten([
+            "${v.target}:*",
+            [
+              for pipe in var.pipes : [
+                for log_config in try([pipe.log_configuration], []) : [
+                  for cloudwatch_log in try([log_config.cloudwatch_logs_log_destination], []) : "${cloudwatch_log.log_group_arn}:*"
+                ]
+              ]
+            ]
+          ]),
           matching_services = ["logs"]
         },
         ecs = {


### PR DESCRIPTION
## Description
CloudWatch policy does not have proper resource and missing ability to use `log_configuration.cloudwatch_logs_log_destination`, targeting CloudWatch in pipes will result in:
```
    "error": {
        "message": "Target invocation failed with error from Logs. Not allowed to invoke.",
        "httpStatusCode": 400,
        "awsService": "logs",
        "exceptionType": "AccessDenied",
    },
```


## Motivation and Context
Fixes issue https://github.com/terraform-aws-modules/terraform-aws-eventbridge/issues/136

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
