### PR TITLE
feat: Added dynamic block for managed_streaming_kafka_parameters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -679,6 +679,27 @@ resource "aws_pipes_pipe" "this" {
         }
       }
 
+      dynamic "managed_streaming_kafka_parameters" {
+        for_each = try([source_parameters.value.managed_streaming_kafka_parameters], [])
+
+        content {
+          batch_size                         = try(managed_streaming_kafka_parameters.value.batch_size, null)
+          maximum_batching_window_in_seconds = try(managed_streaming_kafka_parameters.value.maximum_batching_window_in_seconds, null)
+          consumer_group_id                  = try(managed_streaming_kafka_parameters.value.consumer_group_id, null)
+          starting_position                  = try(managed_streaming_kafka_parameters.value.starting_position, null)
+          topic_name                         = try(managed_streaming_kafka_parameters.value.topic_name, null)
+
+          dynamic "credentials" {
+            for_each = try([managed_streaming_kafka_parameters.value.credentials], [])
+
+            content {
+              client_certificate_tls_auth = credentials.value.client_certificate_tls_auth
+              sasl_scram_512_auth = credentials.value.sasl_scram_512_auth
+            }
+          }
+        }
+      }
+
       dynamic "kinesis_stream_parameters" {
         for_each = try([source_parameters.value.kinesis_stream_parameters], [])
 


### PR DESCRIPTION
## Description
As observed managed_streaming_kafka_parameters was missing from source parameters for aws_pipes_pipe resource in the module.

## Motivation and Context
For serving the events from MSK topic to API destination via eventbridge pipe.

## Breaking Changes
NO breaking changes , only add to support new source_parameter for MSK kafka.
Because it is necessary and valid source_parameter in the official resource for configuring managed_streaming_kafka_parameters pipes.

Supported Reference : [Link](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/pipes_pipe#managed_streaming_kafka_parameters-1


## How Has This Been Tested?

We are using in our project and configuring the pipes from MSK to API Destination , already tested it is up and running no breaking changes occurred.
