### PR TITLE
fix: Step function enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ module "eventbridge" {
   create_archives         = false  # to control creation of EventBridge Archives
   create_permissions      = false  # to control creation of EventBridge Permissions
   create_role             = false  # to control creation of the IAM role and policies required for EventBridge
+  create_pipe_role_only   = false  # to control creation of the IAM role and policies required for EventBridge Pipes only
   create_connections      = false  # to control creation of EventBridge Connection resources
   create_api_destinations = false  # to control creation of EventBridge Destination resources
   create_schedule_groups  = false  # to control creation of EventBridge Schedule Group resources
@@ -496,6 +497,7 @@ No modules.
 | <a name="input_create_bus"></a> [create\_bus](#input\_create\_bus) | Controls whether EventBridge Bus resource should be created | `bool` | `true` | no |
 | <a name="input_create_connections"></a> [create\_connections](#input\_create\_connections) | Controls whether EventBridge Connection resources should be created | `bool` | `false` | no |
 | <a name="input_create_permissions"></a> [create\_permissions](#input\_create\_permissions) | Controls whether EventBridge Permission resources should be created | `bool` | `true` | no |
+| <a name="input_create_pipe_role_only"></a> [create\_pipe\_role\_only](#input\_create\_pipe\_role\_only) | Controls whether an IAM role should be created for the pipes only | `bool` | `false` | no |
 | <a name="input_create_pipes"></a> [create\_pipes](#input\_create\_pipes) | Controls whether EventBridge Pipes resources should be created | `bool` | `true` | no |
 | <a name="input_create_role"></a> [create\_role](#input\_create\_role) | Controls whether IAM roles should be created | `bool` | `true` | no |
 | <a name="input_create_rules"></a> [create\_rules](#input\_create\_rules) | Controls whether EventBridge Rule resources should be created | `bool` | `true` | no |

--- a/examples/with-pipes/README.md
+++ b/examples/with-pipes/README.md
@@ -59,6 +59,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_iam_role_policy_attachment.pipe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kinesis_firehose_delivery_stream.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream) | resource |
 | [aws_kinesis_stream.source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_stream) | resource |
+| [aws_kinesis_stream.target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_stream) | resource |
 | [aws_sqs_queue.dlq](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [aws_sqs_queue.source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [aws_sqs_queue.target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |

--- a/iam.tf
+++ b/iam.tf
@@ -1,7 +1,7 @@
 locals {
   create_role           = var.create && var.create_role
   create_pipes          = var.create && var.create_pipes
-  create_role_for_pipes = local.create_pipes && var.create_role ? true : var.create_pipe_role_only
+  create_role_for_pipes = local.create_pipes && (var.create_role || var.create_pipe_role_only)
 
   # Defaulting to "*" (an invalid character for an IAM Role name) will cause an error when
   # attempting to plan if the role_name and bus_name are not set. This is a workaround

--- a/iam.tf
+++ b/iam.tf
@@ -1,7 +1,7 @@
 locals {
   create_role           = var.create && var.create_role
   create_pipes          = var.create && var.create_pipes
-  create_role_for_pipes = local.create_pipes && var.create_role
+  create_role_for_pipes = local.create_pipes && var.create_role ? true : var.create_pipe_role_only
 
   # Defaulting to "*" (an invalid character for an IAM Role name) will cause an error when
   # attempting to plan if the role_name and bus_name are not set. This is a workaround

--- a/iam_pipes.tf
+++ b/iam_pipes.tf
@@ -33,7 +33,7 @@ locals {
           matching_services = ["lambda"]
         },
         step_functions = {
-          values            = [v.target, try(aws_cloudwatch_event_api_destination.this[v.enrichment].arn, null)],
+          values            = [v.target, try(v.enrichment, null)],
           matching_services = ["states"]
         },
         api_gateway = {

--- a/main.tf
+++ b/main.tf
@@ -694,7 +694,7 @@ resource "aws_pipes_pipe" "this" {
 
             content {
               client_certificate_tls_auth = credentials.value.client_certificate_tls_auth
-              sasl_scram_512_auth = credentials.value.sasl_scram_512_auth
+              sasl_scram_512_auth         = credentials.value.sasl_scram_512_auth
             }
           }
         }

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "create_role" {
   default     = true
 }
 
+variable "create_pipe_role_only" {
+  description = "Controls whether an IAM role should be created for the pipes only"
+  type        = bool
+  default     = false
+}
+
 variable "append_rule_postfix" {
   description = "Controls whether to append '-rule' to the name of the rule"
   type        = bool


### PR DESCRIPTION
## Description
1. Fixes policy creation for step function enrichment
2. Adds a new variable to allow to create only the event bridge pipe role

## Motivation and Context
The new variable allows to create the iam role only for pipe, for the cases where nothing else is created besides pipes, as for now you would end up with an additional role which is not needed

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
