### PR TITLE
fix: Inverted conditional for bus creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ locals {
 }
 
 data "aws_cloudwatch_event_bus" "this" {
-  count = var.create && var.create_bus ? 0 : 1
+  count = var.create && var.create_bus ? 1 : 0
 
   name = var.bus_name
 }


### PR DESCRIPTION
## Description
While attempting to prevent the creation of the event bus I noticed that despite setting `create` and `create_bus` false that the module was still complaining that it couldn't find the event bus resource. 

```
* Failed to execute "terraform apply" in ./.terragrunt-cache/8HF66hbAsRFOCc5OnnuLt3r_uyU/XdD3lc4frNDv5mvmMn0J_6eJy-Y
  ╷
  │ Error: reading EventBridge Event Bus (scheduled-lambda-bus-template-lambda-dev): couldn't find resource
  │ 
  │   with module.eventbridge.data.aws_cloudwatch_event_bus.this[0],
  │   on .terraform/modules/eventbridge/main.tf line 58, in data "aws_cloudwatch_event_bus" "this":
  │   58: data "aws_cloudwatch_event_bus" "this" {
  │ 
  ╵
  
  exit status 1
  ```

It seems the conditional expression is inverted. This PR fixes that.

## Motivation and Context
Fixes `create` and `create_bus` flag behavior to be as expected (e.g., if false then don't make the bus).

## Breaking Changes
No expected breaking changes.

## How Has This Been Tested?
Ultra minor change. Please verify logic and merge. 
