### PR TITLE
fix: Event target for SSM (run_command_targets) should support an array of inputs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,7 @@ resource "aws_cloudwatch_event_target" "this" {
   force_destroy = try(each.value.force_destroy, null)
 
   dynamic "run_command_targets" {
-    for_each = try([each.value.run_command_targets], [])
+    for_each = try(each.value.run_command_targets, [])
 
     content {
       key    = run_command_targets.value.key


### PR DESCRIPTION
## Description
- Remove a mistakenly written brackets on block dynamic run_command_targets

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The main purpose of this fix is to allow create targets for running ssm documents on ec2 instances. In my current company this change would be really appreciated.

Resolves #157

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
Doesn't break any other feature that this module covers

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
     * it is worth to say that there is no example related to ssm as target rule. Someone else could give a try and write a one!
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
