### PR TITLE
feat: Support Event Connection `invocation_connectivity_parameters` and pipes `self_managed_kafka_parameters`, `rabbitmq_broker_parameters` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,13 +382,13 @@ module "eventbridge" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85 |
 
 ## Modules
 

--- a/examples/api-gateway-event-source/README.md
+++ b/examples/api-gateway-event-source/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/api-gateway-event-source/versions.tf
+++ b/examples/api-gateway-event-source/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75.1"
+      version = ">= 5.85"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
@@ -28,7 +28,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75.1"
+      version = ">= 5.85"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/default-bus/README.md
+++ b/examples/default-bus/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/default-bus/versions.tf
+++ b/examples/default-bus/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75.1"
+      version = ">= 5.85"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-api-destination/README.md
+++ b/examples/with-api-destination/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/with-api-destination/versions.tf
+++ b/examples/with-api-destination/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75.1"
+      version = ">= 5.85"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-archive/README.md
+++ b/examples/with-archive/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/with-archive/versions.tf
+++ b/examples/with-archive/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75.1"
+      version = ">= 5.85"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-ecs-scheduling/README.md
+++ b/examples/with-ecs-scheduling/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/with-ecs-scheduling/versions.tf
+++ b/examples/with-ecs-scheduling/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75.1"
+      version = ">= 5.85"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-lambda-scheduling/README.md
+++ b/examples/with-lambda-scheduling/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 

--- a/examples/with-lambda-scheduling/versions.tf
+++ b/examples/with-lambda-scheduling/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75.1"
+      version = ">= 5.85"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-permissions/README.md
+++ b/examples/with-permissions/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/with-permissions/versions.tf
+++ b/examples/with-permissions/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75.1"
+      version = ">= 5.85"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-pipes/README.md
+++ b/examples/with-pipes/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
@@ -28,7 +28,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 

--- a/examples/with-pipes/versions.tf
+++ b/examples/with-pipes/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75.1"
+      version = ">= 5.85"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/with-schedules/README.md
+++ b/examples/with-schedules/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
@@ -28,7 +28,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 

--- a/examples/with-schedules/versions.tf
+++ b/examples/with-schedules/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75.1"
+      version = ">= 5.85"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -425,6 +425,16 @@ resource "aws_cloudwatch_event_connection" "this" {
       }
     }
   }
+
+  dynamic "invocation_connectivity_parameters" {
+    for_each = try([each.value.invocation_connectivity_parameters], [])
+
+    content {
+      resource_parameters {
+        resource_configuration_arn = invocation_connectivity_parameters.value.resource_configuration_arn
+      }
+    }
+  }
 }
 
 resource "aws_cloudwatch_event_api_destination" "this" {
@@ -695,6 +705,55 @@ resource "aws_pipes_pipe" "this" {
             content {
               client_certificate_tls_auth = credentials.value.client_certificate_tls_auth
               sasl_scram_512_auth         = credentials.value.sasl_scram_512_auth
+            }
+          }
+        }
+      }
+
+      dynamic "rabbitmq_broker_parameters" {
+        for_each = try([source_parameters.value.rabbitmq_broker_parameters], [])
+
+        content {
+          batch_size                         = try(rabbitmq_broker_parameters.value.batch_size, null)
+          maximum_batching_window_in_seconds = try(rabbitmq_broker_parameters.value.maximum_batching_window_in_seconds, null)
+          queue_name                         = rabbitmq_broker_parameters.value.queue_name
+          virtual_host                       = try(rabbitmq_broker_parameters.value.virtual_host, null)
+
+          credentials {
+            basic_auth = rabbitmq_broker_parameters.value.basic_auth
+          }
+        }
+      }
+
+      dynamic "self_managed_kafka_parameters" {
+        for_each = try([source_parameters.value.self_managed_kafka_parameters], [])
+
+        content {
+          additional_bootstrap_servers       = try(self_managed_kafka_parameters.value.additional_bootstrap_servers, null)
+          batch_size                         = try(self_managed_kafka_parameters.value.batch_size, null)
+          consumer_group_id                  = try(self_managed_kafka_parameters.value.consumer_group_id, null)
+          maximum_batching_window_in_seconds = try(self_managed_kafka_parameters.value.maximum_batching_window_in_seconds, null)
+          server_root_ca_certificate         = try(self_managed_kafka_parameters.value.server_root_ca_certificate, null)
+          starting_position                  = try(self_managed_kafka_parameters.value.starting_position, null)
+          topic_name                         = try(self_managed_kafka_parameters.value.topic_name, null)
+
+          dynamic "credentials" {
+            for_each = try([self_managed_kafka_parameters.value.credentials], [])
+
+            content {
+              basic_auth                  = try(credentials.value.basic_auth, null)
+              client_certificate_tls_auth = try(credentials.value.client_certificate_tls_auth, null)
+              sasl_scram_256_auth         = try(credentials.value.sasl_scram_256_auth, null)
+              sasl_scram_512_auth         = try(credentials.value.sasl_scram_512_auth, null)
+            }
+          }
+
+          dynamic "vpc" {
+            for_each = try([self_managed_kafka_parameters.value.vpc], [])
+
+            content {
+              security_groups = try(vpc.value.security_groups, null)
+              subnets         = try(vpc.value.vpc, null)
             }
           }
         }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.75.1"
+      version = ">= 5.85"
     }
   }
 }


### PR DESCRIPTION
## Description
Adds support for `aws_cloudwatch_event_connection.invocation_connectivity_parameters`, `aws_pipes_pipe.rabbitmq_broker_parameters`, and `aws_pipes_pipe.self_managed_kafka_parameters`. 

## Motivation and Context
- https://github.com/hashicorp/terraform-provider-aws/pull/41144
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/pipes_pipe#rabbitmq_broker_parameters-2
- closes: https://github.com/terraform-aws-modules/terraform-aws-eventbridge/issues/156

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
