### PR TITLE
feat: Enable ECS-Task as target in the EventBridge Pipes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -874,9 +874,6 @@ resource "aws_pipes_pipe" "this" {
           overrides {
             container_override {
               command            = try(ecs_task_parameters.value.command, [])
-              cpu                = try(ecs_task_parameters.value.cpu, 0)
-              memory             = try(ecs_task_parameters.value.memory, 0)
-              memory_reservation = try(ecs_task_parameters.value.memory_reservation, 0)
               name               = ecs_task_parameters.value.container_name
 
               dynamic "environment" {

--- a/main.tf
+++ b/main.tf
@@ -873,8 +873,8 @@ resource "aws_pipes_pipe" "this" {
 
           overrides {
             container_override {
-              command            = try(ecs_task_parameters.value.command, [])
-              name               = ecs_task_parameters.value.container_name
+              command = try(ecs_task_parameters.value.command, [])
+              name    = ecs_task_parameters.value.container_name
 
               dynamic "environment" {
                 for_each = try(ecs_task_parameters.value.environment, [])

--- a/main.tf
+++ b/main.tf
@@ -851,6 +851,47 @@ resource "aws_pipes_pipe" "this" {
           query_string_parameters = try(http_parameters.value.query_string_parameters, null)
         }
       }
+
+      dynamic "ecs_task_parameters" {
+        for_each = try([target_parameters.value.ecs_task_parameters], [])
+
+        content {
+          enable_ecs_managed_tags = try(ecs_task_parameters.value.enable_ecs_managed_tags, null)
+          enable_execute_command  = try(ecs_task_parameters.value.enable_execute_command, null)
+          launch_type             = try(ecs_task_parameters.value.launch_type, null)
+          platform_version        = try(ecs_task_parameters.value.platform_version, null)
+          task_count              = try(ecs_task_parameters.value.task_count, null)
+          task_definition_arn     = try(ecs_task_parameters.value.task_definition_arn, null)
+
+          network_configuration {
+            aws_vpc_configuration {
+              assign_public_ip = try(ecs_task_parameters.value.assign_public_ip, "DISABLED")
+              security_groups  = try(ecs_task_parameters.value.security_groups, [])
+              subnets          = try(ecs_task_parameters.value.subnets, [])
+            }
+          }
+
+          overrides {
+            container_override {
+              command            = try(ecs_task_parameters.value.command, [])
+              cpu                = try(ecs_task_parameters.value.cpu, 0)
+              memory             = try(ecs_task_parameters.value.memory, 0)
+              memory_reservation = try(ecs_task_parameters.value.memory_reservation, 0)
+              name               = ecs_task_parameters.value.container_name
+
+              dynamic "environment" {
+                for_each = try(ecs_task_parameters.value.environment, [])
+
+                content {
+                  name  = try(environment.value.name, "")
+                  value = try(environment.value.value, "")
+                }
+              }
+            }
+          }
+        }
+      }
+
     }
   }
 


### PR DESCRIPTION
## Description
Add ECS task definition as target to EventBridge Pipes which is currently no supported.

## Motivation and Context
ECS should be integrated with Eventbridge Pipes are its commonly used

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? --> No

## How Has This Been Tested? Yes
  # module.eventbridge_pipes.aws_pipes_pipe.this["example_pipe"] will be created
  + resource "aws_pipes_pipe" "this" {
      + arn           = (known after apply)
      + description   = "Managed by Terraform"
      + desired_state = "RUNNING"
      + id            = (known after apply)
      + name          = "example-pipe-pipe"
      + name_prefix   = (known after apply)
      + role_arn      = "arn:aws:iam::xxxxx:role/service-role/Amazon_EventBridge"
      + source        = "arn:aws:sqs:ap-southeast-1:xxxxd:/abc-staging"
      + tags_all      = (known after apply)
      + target        = "arn:aws:ecs:ap-southeast-1:xxxxx:cluster/abc-staging"

      + source_parameters {
          + activemq_broker_parameters (known after apply)
          + dynamodb_stream_parameters (known after apply)
          + kinesis_stream_parameters (known after apply)
          + managed_streaming_kafka_parameters (known after apply)
          + rabbitmq_broker_parameters (known after apply)
          + self_managed_kafka_parameters (known after apply)
          + sqs_queue_parameters {
              + batch_size                         = 10
              + maximum_batching_window_in_seconds = 30
            }
        }

      + target_parameters {
          + ecs_task_parameters {
              + enable_ecs_managed_tags = false
              + enable_execute_command  = false
              + launch_type             = "FARGATE"
              + platform_version        = "LATEST"
              + task_count              = 1
              + task_definition_arn     = "arn:aws:ecs:ap-southeast-1:xxxxx:task-definition/abc-staging"

              + network_configuration {
                  + aws_vpc_configuration {
                      + assign_public_ip = "DISABLED"
                      + subnets          = [
                          + "subnet-xxxxx",
                          + "subnet-xxxx,
                          + "subnet-xxxx",
                        ]
                    }
                }

              + overrides {
                  + container_override {
                      + command            = []
                      + cpu                = 0
                      + memory             = 0
                      + memory_reservation = 0
                      + name               = "abc-staging"

                      + environment {
                          + name  = "SQS_MESSAGE"
                          + value = "$.body"
                        }
                      + environment {
                          + name  = "SQS_MSG_ATTRIBUTES"
                          + value = "$.messageAttributes"
                        }
                    }
                }
            }
        }
    }


