### PR TITLE
fix: Usage of managed streaming kafka credentials

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -703,8 +703,8 @@ resource "aws_pipes_pipe" "this" {
             for_each = try([managed_streaming_kafka_parameters.value.credentials], [])
 
             content {
-              client_certificate_tls_auth = credentials.value.client_certificate_tls_auth
-              sasl_scram_512_auth         = credentials.value.sasl_scram_512_auth
+              client_certificate_tls_auth = try(credentials.value.client_certificate_tls_auth, null)
+              sasl_scram_512_auth         = try(credentials.value.sasl_scram_512_auth, null)
             }
           }
         }


### PR DESCRIPTION
## Description

For Managed Streaming for Kafka credentials, both [client_certificate_tls_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/pipes_pipe#client_certificate_tls_auth-1) and [sasl_scram_512_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/pipes_pipe#sasl_scram_512_auth-1) are optional. The current implementation does not allow using only one of them independently.

## Motivation and Context

After this change, the following code will be valid for `source_parameters`:

```hcl
source_parameters = {
  managed_streaming_kafka_parameters = {
    topic_name = var.input_kafka_topic
    batch_size = 10
    credentials = {
      sasl_scram_512_auth = var.msk_secret_arn
    }
  }
}
```

Currently, only the following form is accepted:

```hcl
source_parameters = {
  managed_streaming_kafka_parameters = {
    topic_name = var.input_kafka_topic
    batch_size = 10
    credentials = {
      sasl_scram_512_auth         = var.msk_secret_arn
      client_certificate_tls_auth = valid_arn
    }
  }
}
```

## Breaking Changes

No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
