### PR TITLE
Swapped merge to allow for name override

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,33 +5,33 @@ data "aws_partition" "current" {}
 locals {
   eventbridge_rules = flatten([
     for index, rule in var.rules :
-    merge(rule, {
+    merge({
       "name" = index
       "Name" = var.append_rule_postfix ? "${replace(index, "_", "-")}-rule" : index
-    })
+    }, rule)
   ])
   eventbridge_targets = flatten([
     for index, rule in var.rules : [
       for target in var.targets[index] :
-      merge(target, {
+      merge({
         "rule" = index
         "Name" = var.append_rule_postfix ? "${replace(index, "_", "-")}-rule" : index
-      })
+      }, target)
     ] if length(var.targets) != 0
   ])
   eventbridge_connections = flatten([
     for index, conn in var.connections :
-    merge(conn, {
+    merge({
       "name" = index
       "Name" = var.append_connection_postfix ? "${replace(index, "_", "-")}-connection" : index
-    })
+    }, conn)
   ])
   eventbridge_api_destinations = flatten([
     for index, dest in var.api_destinations :
-    merge(dest, {
+    merge({
       "name" = index
       "Name" = var.append_destination_postfix ? "${replace(index, "_", "-")}-destination" : index
-    })
+    }, dest)
   ])
   eventbridge_schedule_groups = {
     for index, group in var.schedule_groups :
@@ -41,17 +41,17 @@ locals {
   }
   eventbridge_schedules = flatten([
     for index, sched in var.schedules :
-    merge(sched, {
+    merge({
       "name" = index
       "Name" = var.append_schedule_postfix ? "${replace(index, "_", "-")}-schedule" : index
-    })
+    }, sched)
   ])
   eventbridge_pipes = flatten([
     for index, pipe in var.pipes :
-    merge(pipe, {
+    merge({
       "name" = index
       "Name" = var.append_pipe_postfix ? "${replace(index, "_", "-")}-pipe" : index
-    })
+    }, pipe)
   ])
 }
 


### PR DESCRIPTION
## Description
Allow for names to be overridden in the configuration.

## Motivation and Context
Without this change, the names derived can lead to issues with length or uniqueness (which we encountered). Allowing the name/Name field to be set, we can override the names when needed in a simple way, while still allowing for the default behavior.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have tested this on a local fork on my production code
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
