### PR TITLE
feat!: Set kms_key_identifier for EventBridge pipes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -667,6 +667,7 @@ resource "aws_pipes_pipe" "this" {
   source = each.value.source
   target = each.value.target
 
+  kms_key_identifier = var.kms_key_identifier
   description   = lookup(each.value, "description", null)
   desired_state = lookup(each.value, "desired_state", null)
 


### PR DESCRIPTION
## Description
The Terraform AWS provider introduces the **kms_key_identifier** property for the "aws_pipes_pipe" resource. This is not yet set by the terraform-aws-eventbridge module

## Motivation and Context
This enables users to set a custom kms key

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
