### PR TITLE
feat: Set kms_key_identifier for EventBridge archives

### DIFF
--- a/examples/with-archive/main.tf
+++ b/examples/with-archive/main.tf
@@ -52,9 +52,8 @@ module "eventbridge" {
 module "eventbridge_archive_only" {
   source = "../../"
 
-  create_bus         = false
-  create_archives    = true
-  kms_key_identifier = module.kms.key_id
+  create_bus      = false
+  create_archives = true
 
   archives = {
     "launch-archive-existing-bus" = {
@@ -67,6 +66,7 @@ module "eventbridge_archive_only" {
           "detail-type" : ["EC2 Instance Launch Successful"]
         }
       )
+      kms_key_identifier = module.kms.key_id
     }
   }
 

--- a/examples/with-archive/main.tf
+++ b/examples/with-archive/main.tf
@@ -120,7 +120,7 @@ module "kms" {
           test     = "StringEquals"
           variable = "aws:SourceArn"
           values = [
-            "arn:aws:events:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:event-bus/example",
+            "arn:aws:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:event-bus/example",
           ]
         }
       ]

--- a/examples/with-archive/main.tf
+++ b/examples/with-archive/main.tf
@@ -7,6 +7,10 @@ provider "aws" {
   skip_credentials_validation = true
 }
 
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+
 module "eventbridge" {
   source = "../../"
 
@@ -50,6 +54,7 @@ module "eventbridge_archive_only" {
 
   create_bus      = false
   create_archives = true
+  kms_key_identifier = module.kms.key_id
 
   archives = {
     "launch-archive-existing-bus" = {
@@ -78,4 +83,49 @@ resource "random_pet" "this" {
 
 resource "aws_cloudwatch_event_bus" "existing_bus" {
   name = "${random_pet.this.id}-existing-bus"
+}
+
+module "kms" {
+  source      = "terraform-aws-modules/kms/aws"
+  version     = "~> 2.0"
+  description = "KMS key for cross region automated backups replication"
+
+  # Aliases
+  aliases                 = ["test"]
+  aliases_use_name_prefix = true
+  key_statements = [
+    {
+      sid = "Allow eventbridge"
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["events.amazonaws.com"]
+        }
+      ]
+      actions = [
+        "kms:DescribeKey",
+        "kms:GenerateDataKey",
+        "kms:Decrypt"
+      ]
+      resources = ["*"]
+      conditions = [
+        {
+          test     = "StringEquals"
+          variable = "kms:EncryptionContext:aws:events:event-bus:arn"
+          values = [
+            "arn:aws:events:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:event-bus/example",
+          ]
+        },
+        {
+          test     = "StringEquals"
+          variable = "aws:SourceArn"
+          values = [
+            "arn:aws:events:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:event-bus/example",
+          ]
+        }
+      ]
+    }
+  ]
+
+  key_owners = [data.aws_caller_identity.current.arn]
 }

--- a/examples/with-archive/main.tf
+++ b/examples/with-archive/main.tf
@@ -113,7 +113,7 @@ module "kms" {
           test     = "StringEquals"
           variable = "kms:EncryptionContext:aws:events:event-bus:arn"
           values = [
-            "arn:aws:events:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:event-bus/example",
+            "arn:aws:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:event-bus/example",
           ]
         },
         {

--- a/examples/with-archive/main.tf
+++ b/examples/with-archive/main.tf
@@ -52,8 +52,8 @@ module "eventbridge" {
 module "eventbridge_archive_only" {
   source = "../../"
 
-  create_bus      = false
-  create_archives = true
+  create_bus         = false
+  create_archives    = true
   kms_key_identifier = module.kms.key_id
 
   archives = {

--- a/examples/with-pipes/main.tf
+++ b/examples/with-pipes/main.tf
@@ -33,7 +33,8 @@ module "eventbridge" {
   }
 
   api_destinations = {
-    smee = { # This key should match the key inside "connections"
+    smee = {
+      # This key should match the key inside "connections"
       description                      = "my smee endpoint"
       invocation_endpoint              = "https://smee.io/6hx6fuQaVUKLfALn"
       http_method                      = "POST"
@@ -47,7 +48,8 @@ module "eventbridge" {
       source = aws_sqs_queue.source.arn
       target = aws_sqs_queue.target.arn
 
-      enrichment = "smee" # This key should match the key inside "api_destinations"
+      enrichment = "smee"
+      # This key should match the key inside "api_destinations"
       enrichment_parameters = {
         input_template = jsonencode({ input : "yes" })
 
@@ -325,6 +327,16 @@ module "eventbridge" {
       }
     }
 
+    custom_kms_key = {
+      source             = aws_sqs_queue.source.arn
+      target             = aws_sqs_queue.target.arn
+      kms_key_identifier = module.kms.key_id
+
+      tags = {
+        Pipe = "minimal"
+      }
+    }
+
     # Minimal with IAM role created outside of the module
     minimal_external_role = {
       create_role = false
@@ -350,39 +362,12 @@ module "eventbridge" {
   }
 }
 
-module "eventbridge_pipe_only" {
-  source = "../../"
-
-  create_bus = false
-
-  pipes = {
-    "pipe-for-existing-bus" = {
-      source             = aws_sqs_queue.source.arn
-      target             = aws_sqs_queue.target.arn
-      kms_key_identifier = module.kms.key_id
-    }
-
-    tags = {
-      Pipe = "pipe-for-existing-bus"
-    }
-  }
-  depends_on = [aws_cloudwatch_event_bus.existing_bus]
-}
-
 ##################
 # Extra resources
 ##################
 
 resource "random_pet" "this" {
   length = 2
-}
-
-###############################
-# Event Bus
-###############################
-
-resource "aws_cloudwatch_event_bus" "existing_bus" {
-  name = "${random_pet.this.id}-existing-bus"
 }
 
 ###############################

--- a/examples/with-pipes/main.tf
+++ b/examples/with-pipes/main.tf
@@ -350,6 +350,25 @@ module "eventbridge" {
   }
 }
 
+module "eventbridge_pipe_only" {
+  source = "../../"
+
+  create_bus = false
+
+  pipes = {
+    "pipe-for-existing-bus" = {
+      source             = aws_sqs_queue.source.arn
+      target             = aws_sqs_queue.target.arn
+      kms_key_identifier = module.kms.key_id
+    }
+
+    tags = {
+      Pipe = "pipe-for-existing-bus"
+    }
+  }
+  depends_on = [aws_cloudwatch_event_bus.existing_bus]
+}
+
 ##################
 # Extra resources
 ##################
@@ -358,6 +377,13 @@ resource "random_pet" "this" {
   length = 2
 }
 
+###############################
+# Event Bus
+###############################
+
+resource "aws_cloudwatch_event_bus" "existing_bus" {
+  name = "${random_pet.this.id}-existing-bus"
+}
 
 ###############################
 # API Destination / Connection

--- a/main.tf
+++ b/main.tf
@@ -286,6 +286,7 @@ resource "aws_cloudwatch_event_archive" "this" {
 
   name             = lookup(each.value, "name", each.key)
   event_source_arn = try(each.value["event_source_arn"], aws_cloudwatch_event_bus.this[0].arn)
+  kms_key_identifier = var.kms_key_identifier
 
   description    = lookup(each.value, "description", null)
   event_pattern  = lookup(each.value, "event_pattern", null)

--- a/main.tf
+++ b/main.tf
@@ -668,6 +668,7 @@ resource "aws_pipes_pipe" "this" {
   source = each.value.source
   target = each.value.target
 
+  kms_key_identifier = var.kms_key_identifier
   description   = lookup(each.value, "description", null)
   desired_state = lookup(each.value, "desired_state", null)
 

--- a/main.tf
+++ b/main.tf
@@ -669,8 +669,8 @@ resource "aws_pipes_pipe" "this" {
   target = each.value.target
 
   kms_key_identifier = var.kms_key_identifier
-  description   = lookup(each.value, "description", null)
-  desired_state = lookup(each.value, "desired_state", null)
+  description        = lookup(each.value, "description", null)
+  desired_state      = lookup(each.value, "desired_state", null)
 
   dynamic "source_parameters" {
     for_each = try([each.value.source_parameters], [])

--- a/main.tf
+++ b/main.tf
@@ -284,13 +284,13 @@ resource "aws_cloudwatch_event_archive" "this" {
 
   region = var.region
 
-  name               = lookup(each.value, "name", each.key)
-  event_source_arn   = try(each.value["event_source_arn"], aws_cloudwatch_event_bus.this[0].arn)
-  kms_key_identifier = var.kms_key_identifier
+  name             = lookup(each.value, "name", each.key)
+  event_source_arn = try(each.value["event_source_arn"], aws_cloudwatch_event_bus.this[0].arn)
 
-  description    = lookup(each.value, "description", null)
-  event_pattern  = lookup(each.value, "event_pattern", null)
-  retention_days = lookup(each.value, "retention_days", null)
+  description        = lookup(each.value, "description", null)
+  event_pattern      = lookup(each.value, "event_pattern", null)
+  retention_days     = lookup(each.value, "retention_days", null)
+  kms_key_identifier = lookup(each.value, "kms_key_identifier", null)
 }
 
 resource "aws_cloudwatch_event_permission" "this" {
@@ -668,7 +668,7 @@ resource "aws_pipes_pipe" "this" {
   source = each.value.source
   target = each.value.target
 
-  kms_key_identifier = var.kms_key_identifier
+  kms_key_identifier = lookup(each.value, "kms_key_identifier", null)
   description        = lookup(each.value, "description", null)
   desired_state      = lookup(each.value, "desired_state", null)
 

--- a/main.tf
+++ b/main.tf
@@ -284,8 +284,8 @@ resource "aws_cloudwatch_event_archive" "this" {
 
   region = var.region
 
-  name             = lookup(each.value, "name", each.key)
-  event_source_arn = try(each.value["event_source_arn"], aws_cloudwatch_event_bus.this[0].arn)
+  name               = lookup(each.value, "name", each.key)
+  event_source_arn   = try(each.value["event_source_arn"], aws_cloudwatch_event_bus.this[0].arn)
   kms_key_identifier = var.kms_key_identifier
 
   description    = lookup(each.value, "description", null)

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0"
+      version = ">= 6.2"
     }
   }
 }


### PR DESCRIPTION
## Description
The Terraform AWS provider introduces the kms_key_identifier property for the "aws_cloudwatch_event_archive" resource. This is not yet set by the terraform-aws-eventbridge module

## Motivation and Context
This enables users to set a custom kms key

## Breaking Changes
No, not directly. Although I'm not yet sure how an existing archive reacts to re-keying. Might be worth mentioning.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
