### PR TITLE
fix: Bug where permission_boundary var not available to the eventbridge_pipe IAM Role

### DIFF
--- a/iam_pipes.tf
+++ b/iam_pipes.tf
@@ -358,7 +358,7 @@ resource "aws_iam_role" "eventbridge_pipe" {
   description           = try(each.value.role_description, null)
   path                  = try(each.value.role_path, null)
   force_detach_policies = try(each.value.role_force_detach_policies, null)
-  permissions_boundary  = try(each.value.role_permissions_boundary, null)
+  permissions_boundary  = var.role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.assume_role_pipe[each.key].json
 
   tags = merge({ Name = each.value.role_name }, try(each.value.role_tags, {}), var.tags)


### PR DESCRIPTION
## Description
This PR fixes a bug where the role_permissions_boundary variable was not available to the eventbridge_pipe IAM Role.  

## Motivation and Context
Without this fix eventbridge pipes IAM roles were not being created where a permissions boundary was set in the account

## Breaking Changes
Non-Breaking Change

## How Has This Been Tested?
I have confirmed this change works because I can now successfully create the eventbridge pipe where previously I received the following error

`user is not authorized to perform: iam:CreateRole on resource: xxxx with an explicit deny in a permissions boundary`
