### PR TITLE
fix: Ensure targets are destroyed before rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -183,7 +183,7 @@ resource "aws_cloudwatch_event_target" "this" {
 
   event_bus_name = var.create_bus ? aws_cloudwatch_event_bus.this[0].name : var.bus_name
 
-  rule = each.value.Name
+  rule = aws_cloudwatch_event_rule.this[each.value.rule].name
   arn  = lookup(each.value, "destination", null) != null ? aws_cloudwatch_event_api_destination.this[each.value.destination].arn : each.value.arn
 
   role_arn = can(length(each.value.attach_role_arn) > 0) ? each.value.attach_role_arn : (try(each.value.attach_role_arn, null) == true ? aws_iam_role.eventbridge[0].arn : null)
@@ -337,8 +337,6 @@ resource "aws_cloudwatch_event_target" "this" {
       maximum_retry_attempts       = retry_policy.value.maximum_retry_attempts
     }
   }
-
-  depends_on = [aws_cloudwatch_event_rule.this]
 }
 
 resource "aws_cloudwatch_event_archive" "this" {


### PR DESCRIPTION
## Summary

- Replace string reference with resource reference to create implicit dependency between each target and its specific rule
- Remove redundant blanket `depends_on` that could cause destroy ordering issues

## Problem

When destroying EventBridge resources, Terraform sometimes fails with:
```
Error: deleting EventBridge Rule: Rule can't be deleted since it has targets.
```

This happens because:
1. The `rule` attribute used `each.value.Name` (a string from locals), creating no implicit dependency
2. The `depends_on = [aws_cloudwatch_event_rule.this]` created a blanket dependency on ALL rules
3. During complex destroys (especially when Lambda targets are also being destroyed), the ordering could break

## Solution

Replace:
```hcl
rule = each.value.Name
# ...
depends_on = [aws_cloudwatch_event_rule.this]
```

With:
```hcl
rule = aws_cloudwatch_event_rule.this[each.value.rule].name
```

This creates an implicit dependency on the **specific** rule that the target belongs to, ensuring:
- During creation: rule is created before its targets
- During destruction: targets are destroyed before their specific rule

## Test plan

- [ ] Verify `terraform validate` passes
- [ ] Apply an example configuration with rules and targets
- [ ] Run `terraform destroy` and verify targets are destroyed before rules
- [ ] Test destroy when Lambda function targets are also being destroyed

🤖 Generated with [Клауд Коденко](https://claude.ai/code)
Слава Україні!