### PR TITLE
fix: Separate KMS statement in SQS policy with dedicated sqs_kms_arns variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ No modules.
 | <a name="input_sfn_target_arns"></a> [sfn\_target\_arns](#input\_sfn\_target\_arns) | The Amazon Resource Name (ARN) of the StepFunctions you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_sns_kms_arns"></a> [sns\_kms\_arns](#input\_sns\_kms\_arns) | The Amazon Resource Name (ARN) of the AWS KMS's configured for AWS SNS you want Decrypt/GenerateDataKey for | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
 | <a name="input_sns_target_arns"></a> [sns\_target\_arns](#input\_sns\_target\_arns) | The Amazon Resource Name (ARN) of the AWS SNS's you want to use as EventBridge targets | `list(string)` | `[]` | no |
+| <a name="input_sqs_kms_arns"></a> [sqs\_kms\_arns](#input\_sqs\_kms\_arns) | The Amazon Resource Name (ARN) of the AWS KMS keys configured for AWS SQS you want Decrypt/GenerateDataKey permissions for | `list(string)` | `[]` | no |
 | <a name="input_sqs_target_arns"></a> [sqs\_target\_arns](#input\_sqs\_target\_arns) | The Amazon Resource Name (ARN) of the AWS SQS Queues you want to use as EventBridge targets | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | `{}` | no |
 | <a name="input_targets"></a> [targets](#input\_targets) | A map of objects with EventBridge Target definitions. | `any` | `{}` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -145,14 +145,24 @@ data "aws_iam_policy_document" "sqs" {
   count = local.create_role && var.attach_sqs_policy ? 1 : 0
 
   statement {
-    sid    = "SQSAccess"
-    effect = "Allow"
-    actions = [
-      "sqs:SendMessage*",
-      "kms:Decrypt",
-      "kms:GenerateDataKey"
-    ]
+    sid       = "SQSAccess"
+    effect    = "Allow"
+    actions   = ["sqs:SendMessage*"]
     resources = var.sqs_target_arns
+  }
+
+  dynamic "statement" {
+    for_each = length(var.sqs_kms_arns) > 0 ? [1] : []
+
+    content {
+      sid    = "SQSKMSAccess"
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = var.sqs_kms_arns
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -407,6 +407,12 @@ variable "sqs_target_arns" {
   default     = []
 }
 
+variable "sqs_kms_arns" {
+  description = "The Amazon Resource Name (ARN) of the AWS KMS keys configured for AWS SQS you want Decrypt/GenerateDataKey permissions for"
+  type        = list(string)
+  default     = []
+}
+
 variable "sns_target_arns" {
   description = "The Amazon Resource Name (ARN) of the AWS SNS's you want to use as EventBridge targets"
   type        = list(string)


### PR DESCRIPTION
## Problem

The SQS IAM policy document (in `iam.tf`) placed `kms:Decrypt` and `kms:GenerateDataKey` in the same statement as `sqs:SendMessage*`, using only `var.sqs_target_arns` (SQS ARNs) as resources:

```hcl
actions = [
  "sqs:SendMessage*",
  "kms:Decrypt",           # ← KMS action
  "kms:GenerateDataKey"    # ← KMS action
]
resources = var.sqs_target_arns  # ← SQS ARNs, not KMS ARNs
```

IAM does not error at creation time, but at runtime KMS calls fail because SQS ARNs are not valid resources for KMS actions. The KMS permissions were effectively non-functional.

## Fix

Split into two statements, following the same pattern already used for SNS:

1. `SQSAccess` — `sqs:SendMessage*` scoped to `var.sqs_target_arns`
2. `SQSKMSAccess` — `kms:Decrypt` / `kms:GenerateDataKey` scoped to a new `var.sqs_kms_arns` variable (only emitted when non-empty)

## Changes

- `iam.tf`: split SQS policy into two statements using a `dynamic` block for KMS
- `variables.tf`: add `sqs_kms_arns` variable (default `[]`, so existing configs are unaffected)
- `README.md`: document the new `sqs_kms_arns` input variable

## Backward compatibility

Users not passing `sqs_kms_arns` are unaffected — the KMS statement is omitted entirely when the list is empty. Users who were relying on the broken KMS permissions (they weren't working) need to add `sqs_kms_arns` with their KMS key ARNs.