### PR TITLE
fix: Filter out deprecated `is_enabled` in `eventbridge_rules` output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -143,7 +143,23 @@ output "eventbridge_targets" {
 
 output "eventbridge_rules" {
   description = "The EventBridge Rules created and their attributes"
-  value       = aws_cloudwatch_event_rule.this
+  value = {
+    for k, v in aws_cloudwatch_event_rule.this : k => {
+      arn                 = v.arn
+      description         = v.description
+      event_bus_name      = v.event_bus_name
+      event_pattern       = v.event_pattern
+      force_destroy       = v.force_destroy
+      id                  = v.id
+      name                = v.name
+      name_prefix         = v.name_prefix
+      role_arn            = v.role_arn
+      schedule_expression = v.schedule_expression
+      state               = v.state
+      tags                = v.tags
+      tags_all            = v.tags_all
+    }
+  }
 }
 
 output "eventbridge_schedule_groups" {


### PR DESCRIPTION
## Description

The `eventbridge_rules` output was returning the full `aws_cloudwatch_event_rule.this` resource object, which includes the deprecated `is_enabled` attribute. As of AWS provider v6 and Terraform v1.15+, this causes a deprecation warning on every `terraform plan`/`apply`:

```
╷
│ Warning: Deprecated value used
│
│   on .terraform/modules/eventbridge/outputs.tf line 146, in output "eventbridge_rules":
│  146:   value       = aws_cloudwatch_event_rule.this
│
│   The deprecation originates from module.eventbridge.aws_cloudwatch_event_rule.this["rule"].is_enabled
│
│ is_enabled is deprecated. Use state instead.
╵
```

## Solution

Replace the raw resource reference in the `eventbridge_rules` output with an explicit `for` expression that enumerates only the non-deprecated attributes, using `state` instead of `is_enabled`.

## Related issues

Fixes #199