### PR TITLE
fix: Only create log delivery source when the bus emits logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,11 @@ locals {
   ])
 
   create_log_delivery = var.create && var.create_log_delivery
+
+  # The enabled log deliveries, resolved once. The delivery destination and delivery
+  # resources iterate this directly, and the delivery source is created only when it
+  # is non-empty, so the source can never outlive the deliveries that reference it.
+  log_delivery_enabled = { for k, v in var.log_delivery : k => v if local.create_log_delivery && try(v.enabled, true) }
 }
 
 data "aws_cloudwatch_event_bus" "this" {
@@ -94,10 +99,9 @@ resource "aws_cloudwatch_event_bus" "this" {
 }
 
 resource "aws_cloudwatch_log_delivery_source" "this" {
-  # Only create the delivery source when at least one enabled log delivery is configured, otherwise it
-  # is created for every bus even when no `log_delivery` is set. The predicate mirrors the for_each
-  # filter on the delivery destination/delivery resources below so the source never outlives them.
-  count = local.create_log_delivery && var.create_log_delivery_source && length([for k, v in var.log_delivery : k if try(v.enabled, true)]) > 0 ? 1 : 0
+  # Only create the delivery source when at least one enabled log delivery is configured;
+  # otherwise it is created for every bus even when no `log_delivery` is set.
+  count = var.create_log_delivery_source && length(local.log_delivery_enabled) > 0 ? 1 : 0
 
   region = var.region
 
@@ -109,7 +113,7 @@ resource "aws_cloudwatch_log_delivery_source" "this" {
 }
 
 resource "aws_cloudwatch_log_delivery_destination" "this" {
-  for_each = { for k, v in var.log_delivery : k => v if(local.create_log_delivery && try(v.enabled, true)) }
+  for_each = local.log_delivery_enabled
 
   region = var.region
 
@@ -124,7 +128,7 @@ resource "aws_cloudwatch_log_delivery_destination" "this" {
 }
 
 resource "aws_cloudwatch_log_delivery" "this" {
-  for_each = { for k, v in var.log_delivery : k => v if(local.create_log_delivery && try(v.enabled, true)) }
+  for_each = local.log_delivery_enabled
 
   region = var.region
 

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,10 @@ resource "aws_cloudwatch_event_bus" "this" {
 }
 
 resource "aws_cloudwatch_log_delivery_source" "this" {
-  count = local.create_log_delivery && var.create_log_delivery_source ? 1 : 0
+  # Only create the delivery source when at least one enabled log delivery is configured, otherwise it
+  # is created for every bus even when no `log_delivery` is set. The predicate mirrors the for_each
+  # filter on the delivery destination/delivery resources below so the source never outlives them.
+  count = local.create_log_delivery && var.create_log_delivery_source && length([for k, v in var.log_delivery : k if try(v.enabled, true)]) > 0 ? 1 : 0
 
   region = var.region
 

--- a/main.tf
+++ b/main.tf
@@ -56,9 +56,8 @@ locals {
 
   create_log_delivery = var.create && var.create_log_delivery
 
-  # The enabled log deliveries, resolved once. The delivery destination and delivery
-  # resources iterate this directly, and the delivery source is created only when it
-  # is non-empty, so the source can never outlive the deliveries that reference it.
+  # The enabled log deliveries, resolved once and iterated directly by the delivery
+  # destination and delivery resources.
   log_delivery_enabled = { for k, v in var.log_delivery : k => v if local.create_log_delivery && try(v.enabled, true) }
 }
 
@@ -99,9 +98,11 @@ resource "aws_cloudwatch_event_bus" "this" {
 }
 
 resource "aws_cloudwatch_log_delivery_source" "this" {
-  # Only create the delivery source when at least one enabled log delivery is configured;
-  # otherwise it is created for every bus even when no `log_delivery` is set.
-  count = var.create_log_delivery_source && length(local.log_delivery_enabled) > 0 ? 1 : 0
+  # Create the source when the bus actually emits logs (`log_config`) or when an enabled
+  # delivery references it. Without either, the source was created for every bus even
+  # though nothing consumed it (#201). The `log_delivery` half of the predicate also keeps
+  # the reference on `aws_cloudwatch_log_delivery.this` below from dangling.
+  count = local.create_log_delivery && var.create_log_delivery_source && (var.log_config != null || length(local.log_delivery_enabled) > 0) ? 1 : 0
 
   region = var.region
 


### PR DESCRIPTION
When `create` and `create_log_delivery` are at their defaults (both true), `aws_cloudwatch_log_delivery_source.this` was created for every bus even when no `log_delivery` was configured (#201). The delivery destination and delivery resources are already gated on `var.log_delivery` entries, but the source was not, so an orphan source with a default `ERROR_LOGS` log_type appeared in the plan after upgrading to v4.20.

This gates the source's `count` on the exact same predicate the delivery destination/delivery resources use for their `for_each` — `length([for k, v in var.log_delivery : k if try(v.enabled, true)]) > 0` — so the source is created only when at least one **enabled** log delivery is configured. This also covers the case where every `log_delivery` entry has `enabled = false`: in that case no destination/delivery is created, so no orphan source is created either. Backward compatible: configurations with an enabled `log_delivery` still get the source.

Validation (local):
- `terraform fmt -check`: pass
- `terraform validate`: Success
- `tflint`: exit 0
- No variable or output change, so the generated docs are unchanged.

closes #201
