### PR TITLE
fix: Remove depreciated values from IAM role outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ No modules.
 | <a name="output_eventbridge_connection_arns"></a> [eventbridge\_connection\_arns](#output\_eventbridge\_connection\_arns) | The EventBridge Connection Arns |
 | <a name="output_eventbridge_connection_ids"></a> [eventbridge\_connection\_ids](#output\_eventbridge\_connection\_ids) | The EventBridge Connection IDs |
 | <a name="output_eventbridge_connections"></a> [eventbridge\_connections](#output\_eventbridge\_connections) | The EventBridge Connections created and their attributes |
-| <a name="output_eventbridge_iam_roles"></a> [eventbridge\_iam\_roles](#output\_eventbridge\_iam\_roles) | The EventBridge IAM roles created and their attributes |
+| <a name="output_eventbridge_iam_roles"></a> [eventbridge\_iam\_roles](#output\_eventbridge\_iam\_roles) | The EventBridge IAM roles created and their key attributes |
 | <a name="output_eventbridge_log_delivery_source_arn"></a> [eventbridge\_log\_delivery\_source\_arn](#output\_eventbridge\_log\_delivery\_source\_arn) | The EventBridge Bus CloudWatch Log Delivery Source ARN |
 | <a name="output_eventbridge_log_delivery_source_name"></a> [eventbridge\_log\_delivery\_source\_name](#output\_eventbridge\_log\_delivery\_source\_name) | The EventBridge Bus CloudWatch Log Delivery Source Name |
 | <a name="output_eventbridge_permission_ids"></a> [eventbridge\_permission\_ids](#output\_eventbridge\_permission\_ids) | The EventBridge Permission IDs |
@@ -592,7 +592,7 @@ No modules.
 | <a name="output_eventbridge_pipe_role_arns"></a> [eventbridge\_pipe\_role\_arns](#output\_eventbridge\_pipe\_role\_arns) | The ARNs of the IAM role created for EventBridge Pipes |
 | <a name="output_eventbridge_pipe_role_names"></a> [eventbridge\_pipe\_role\_names](#output\_eventbridge\_pipe\_role\_names) | The names of the IAM role created for EventBridge Pipes |
 | <a name="output_eventbridge_pipes"></a> [eventbridge\_pipes](#output\_eventbridge\_pipes) | The EventBridge Pipes created and their attributes |
-| <a name="output_eventbridge_pipes_iam_roles"></a> [eventbridge\_pipes\_iam\_roles](#output\_eventbridge\_pipes\_iam\_roles) | The EventBridge Pipes IAM roles created and their attributes |
+| <a name="output_eventbridge_pipes_iam_roles"></a> [eventbridge\_pipes\_iam\_roles](#output\_eventbridge\_pipes\_iam\_roles) | The EventBridge Pipes IAM roles created and their key attributes |
 | <a name="output_eventbridge_role_arn"></a> [eventbridge\_role\_arn](#output\_eventbridge\_role\_arn) | The ARN of the IAM role created for EventBridge |
 | <a name="output_eventbridge_role_name"></a> [eventbridge\_role\_name](#output\_eventbridge\_role\_name) | The name of the IAM role created for EventBridge |
 | <a name="output_eventbridge_rule_arns"></a> [eventbridge\_rule\_arns](#output\_eventbridge\_rule\_arns) | The EventBridge Rule ARNs |

--- a/outputs.tf
+++ b/outputs.tf
@@ -189,7 +189,6 @@ output "eventbridge_log_delivery_source_name" {
 }
 
 # IAM Roles
-# IAM Roles
 output "eventbridge_pipes_iam_roles" {
   description = "The EventBridge Pipes IAM roles created and their key attributes"
   value = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -189,12 +189,41 @@ output "eventbridge_log_delivery_source_name" {
 }
 
 # IAM Roles
+# IAM Roles
 output "eventbridge_pipes_iam_roles" {
-  description = "The EventBridge Pipes IAM roles created and their attributes"
-  value       = aws_iam_role.eventbridge_pipe
+  description = "The EventBridge Pipes IAM roles created and their key attributes"
+  value = {
+    for k, v in aws_iam_role.eventbridge_pipe : k => {
+      arn                  = v.arn
+      create_date          = v.create_date
+      description          = v.description
+      force_detach_policies = v.force_detach_policies
+      id                   = v.id
+      max_session_duration = v.max_session_duration
+      name                 = v.name
+      path                 = v.path
+      permissions_boundary = v.permissions_boundary
+      tags                 = v.tags
+      unique_id            = v.unique_id
+    }
+  }
 }
 
 output "eventbridge_iam_roles" {
-  description = "The EventBridge IAM roles created and their attributes"
-  value       = aws_iam_role.eventbridge
+  description = "The EventBridge IAM roles created and their key attributes"
+  value = [
+    for v in aws_iam_role.eventbridge : {
+      arn                  = v.arn
+      create_date          = v.create_date
+      description          = v.description
+      force_detach_policies = v.force_detach_policies
+      id                   = v.id
+      max_session_duration = v.max_session_duration
+      name                 = v.name
+      path                 = v.path
+      permissions_boundary = v.permissions_boundary
+      tags                 = v.tags
+      unique_id            = v.unique_id
+    }
+  ]
 }


### PR DESCRIPTION
## Description
Replace `eventbridge_iam_roles` and `eventbridge_pipes_iam_roles` outputs, which currently output all attributes, with objects that return specific attributes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`managed_policy_arns` and `inline_policy` attributes of `aws_iam_role` resource are depreciated and produce a depreciated attribute warning that is displayed in the plan output after upgrading to OpenTofu v1.12.x 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- ✅ I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- ✅ I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
