### PR TITLE
fix: Add Firehose batch permission for pipes

### DIFF
--- a/examples/with-pipes/main.tf
+++ b/examples/with-pipes/main.tf
@@ -273,6 +273,22 @@ module "eventbridge" {
       }
     }
 
+    # With SQS Queue source and Firehose target
+    sqs_source_firehose_target = {
+      source = aws_sqs_queue.source.arn
+      target = aws_kinesis_firehose_delivery_stream.logs.arn
+
+      source_parameters = {
+        sqs_queue_parameters = {
+          batch_size = 2
+        }
+      }
+
+      tags = {
+        Pipe = "sqs_source_firehose_target"
+      }
+    }
+
     # With SQS Queue source and StepFunction target
     sqs_source_step_function_target = {
       source = aws_sqs_queue.source.arn

--- a/iam_pipes.tf
+++ b/iam_pipes.tf
@@ -290,7 +290,8 @@ locals {
 
     firehose = {
       actions = [
-        "firehose:PutRecord"
+        "firehose:PutRecord",
+        "firehose:PutRecordBatch"
       ]
     }
 


### PR DESCRIPTION
## Description

Add `firehose:PutRecordBatch` to the generated EventBridge Pipes execution-role policy alongside the existing `firehose:PutRecord` permission.

The canonical `with-pipes` example now includes an SQS source with `batch_size = 2` targeting its existing Firehose delivery stream, so repository validation exercises the affected service-integration path.

## Motivation and Context

EventBridge Pipes can invoke Firehose with `PutRecordBatch` when the source produces a batch. The generated role currently grants only `PutRecord`, causing batched target invocations to fail with `AccessDenied`.

Closes #205.

## Breaking Changes

None. This only adds the missing action to an existing Firehose target policy.

## How Has This Been Tested?

- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
  - Terraform 1.15.8: all root and 11 example configurations initialized and validated successfully
  - Terraform 1.5.7: all root and 11 example configurations validated successfully
  - `terraform console` on both versions returned exactly `firehose:PutRecord` and `firehose:PutRecordBatch` for the Firehose service policy
  - `terraform fmt`, `terraform-docs`, TFLint, and diff checks passed
  - No AWS resources were applied locally
- [ ] I have executed `pre-commit run -a` on my pull request
  - The combined parallel validate hook exceeded local disk while initializing every example simultaneously. Its fmt/docs/TFLint stages passed; the complete validate matrix was rerun sequentially with a shared provider cache as documented above.
