### PR TITLE
fix: Remove deprecation on aws_iam_role by filtering them out (inline_policy and managed_policy_arns)

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -191,10 +191,44 @@ output "eventbridge_log_delivery_source_name" {
 # IAM Roles
 output "eventbridge_pipes_iam_roles" {
   description = "The EventBridge Pipes IAM roles created and their attributes"
-  value       = aws_iam_role.eventbridge_pipe
+  value = {
+    for k, v in aws_iam_role.eventbridge_pipe : k => {
+      arn                   = v.arn
+      assume_role_policy    = v.assume_role_policy
+      create_date           = v.create_date
+      description           = v.description
+      force_detach_policies = v.force_detach_policies
+      id                    = v.id
+      max_session_duration  = v.max_session_duration
+      name                  = v.name
+      name_prefix           = v.name_prefix
+      path                  = v.path
+      permissions_boundary  = v.permissions_boundary
+      tags                  = v.tags
+      tags_all              = v.tags_all
+      unique_id             = v.unique_id
+    }
+  }
 }
 
 output "eventbridge_iam_roles" {
   description = "The EventBridge IAM roles created and their attributes"
-  value       = aws_iam_role.eventbridge
+  value = [
+    for v in aws_iam_role.eventbridge : {
+      arn                   = v.arn
+      assume_role_policy    = v.assume_role_policy
+      create_date           = v.create_date
+      description           = v.description
+      force_detach_policies = v.force_detach_policies
+      id                    = v.id
+      max_session_duration  = v.max_session_duration
+      name                  = v.name
+      name_prefix           = v.name_prefix
+      path                  = v.path
+      permissions_boundary  = v.permissions_boundary
+      tags                  = v.tags
+      tags_all              = v.tags_all
+      unique_id             = v.unique_id
+    }
+  ]
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

With the latest AWS provider version, some outputs on the `aws_iam_role` resource are deprecated (`inline_policy` and `managed_policy_arns`).

> `managed_policy_arns` is deprecated. Use the `aws_iam_role_policy_attachment`
> resource instead. If Terraform should exclusively manage all managed policy
> attachments (the current behavior of this argument), use the
> `aws_iam_role_policy_attachments_exclusive` resource as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We filter out all deprecated outputs.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

This is not a breaking change, since `inline_policy` and `managed_policy_arns` are not meant to be used here — this module doesn't set them on the `aws_iam_role` resource.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->